### PR TITLE
Add API response DTO with timestamp

### DIFF
--- a/src/main/java/com/ahumadamob/billeteraapi/dto/response/ApiResponse.java
+++ b/src/main/java/com/ahumadamob/billeteraapi/dto/response/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.ahumadamob.billeteraapi.dto.response;
+
+import java.time.Instant;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApiResponse<T> {
+    private String message;
+    private T data;
+
+    @Builder.Default
+    private Instant timestamp = Instant.now();
+}
+


### PR DESCRIPTION
## Summary
- add generic `ApiResponse` DTO to wrap successful responses

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c327500784832fa826aa01daba7d14