### PR TITLE
Add auditing fields to BaseEntity and refactor Picture

### DIFF
--- a/src/main/java/com/ahumadamob/billeteraapi/entity/BaseEntity.java
+++ b/src/main/java/com/ahumadamob/billeteraapi/entity/BaseEntity.java
@@ -1,12 +1,17 @@
 package com.ahumadamob.billeteraapi.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @MappedSuperclass
 @Getter
@@ -17,4 +22,22 @@ public abstract class BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/ahumadamob/billeteraapi/entity/Picture.java
+++ b/src/main/java/com/ahumadamob/billeteraapi/entity/Picture.java
@@ -2,7 +2,6 @@ package com.ahumadamob.billeteraapi.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,8 +15,6 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Max;
 
 import org.hibernate.validator.constraints.URL;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "pictures")
@@ -58,15 +55,4 @@ public class Picture extends BaseEntity {
     @Column(name = "cover", nullable = false)
     @NotNull
     private Boolean cover = false;
-
-    @Column(name = "created_date", nullable = false)
-    @NotNull
-    private LocalDateTime createdDate;
-
-    @PrePersist
-    public void prePersist() {
-        if (createdDate == null) {
-            createdDate = LocalDateTime.now();
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- add createdAt and updatedAt auditing fields in BaseEntity with automatic timestamps
- simplify Picture entity to rely on BaseEntity timestamps

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6169e61f8832fb788c161a4fb8482