### PR TITLE
feat: implement serializable base entity and API response DTOs

### DIFF
--- a/src/main/java/com/ahumadamob/billeteraapi/dto/response/ApiResponseSuccessDto.java
+++ b/src/main/java/com/ahumadamob/billeteraapi/dto/response/ApiResponseSuccessDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class ApiResponse<T> {
+public class ApiResponseSuccessDto<T> {
     private String message;
     private T data;
 

--- a/src/main/java/com/ahumadamob/billeteraapi/entity/BaseEntity.java
+++ b/src/main/java/com/ahumadamob/billeteraapi/entity/BaseEntity.java
@@ -1,24 +1,64 @@
 package com.ahumadamob.billeteraapi.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
 import java.io.Serializable;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Clase base para las entidades JPA que provee una clave primaria generada junto
+ * con marcas de tiempo de creación y actualización y un indicador de borrado lógico.
+ */
 @MappedSuperclass
 @Getter
 @Setter
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 public abstract class BaseEntity implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Identificador de clave primaria generado automáticamente.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @EqualsAndHashCode.Include
     private Long id;
+
+    /**
+     * Marca de tiempo que registra cuándo se creó la entidad.
+     */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * Marca de tiempo que registra la última vez que se actualizó la entidad.
+     */
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /**
+     * Indicador que señala si la entidad fue borrada lógicamente.
+     */
+    @Column(name = "deleted", nullable = false)
+    private Boolean deleted = false;
+
+    @PrePersist
+    private void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    private void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/ahumadamob/billeteraapi/error/dto/ApiResponseErrorDto.java
+++ b/src/main/java/com/ahumadamob/billeteraapi/error/dto/ApiResponseErrorDto.java
@@ -1,0 +1,45 @@
+package com.ahumadamob.billeteraapi.error.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Objeto de transferencia que representa una respuesta de error de la API.
+ * Contiene una lista de mensajes de error por campo y una marca de tiempo
+ * que indica cuándo se produjo el error.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponseErrorDto {
+
+    /**
+     * Colección de mensajes que describen errores para campos específicos.
+     */
+    private List<Message> messages;
+
+    /**
+     * Momento en el que se creó la respuesta de error.
+     */
+    @Builder.Default
+    private Instant timestamp = Instant.now();
+
+    /**
+     * Representa el error de un campo.
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Message {
+        private String field;
+        private String value;
+    }
+}
+


### PR DESCRIPTION
## Summary
- define serialVersionUID for BaseEntity
- add automatic created/updated timestamps and soft delete flag
- remove custom equality logic
- rename ApiResponseDto to ApiResponseSuccessDto with timestamp
- introduce ApiResponseErrorDto listing field/value errors
- translate comments to Spanish

## Testing
- `mvn -q -DskipTests=true compile` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q -DskipTests=true javadoc:javadoc` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c61a0fc32c832fb984cf8ca78d9cd8