### PR TITLE
Add Usuario entity with base currency enum and repository

### DIFF
--- a/src/main/java/com/ahumadamob/billeteraapi/entity/Usuario.java
+++ b/src/main/java/com/ahumadamob/billeteraapi/entity/Usuario.java
@@ -1,0 +1,44 @@
+package com.ahumadamob.billeteraapi.entity;
+
+import com.ahumadamob.billeteraapi.enums.Moneda;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Representa a un usuario del sistema.
+ */
+@Entity
+@Table(name = "usuario")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Usuario extends BaseEntity {
+
+    @Column(name = "nombre", nullable = false)
+    @NotBlank
+    private String nombre;
+
+    @Column(name = "email", nullable = false, unique = true)
+    @NotBlank
+    @Email
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    @NotBlank
+    private String passwordHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "moneda_base", nullable = false)
+    private Moneda monedaBase;
+
+    @Column(name = "activo", nullable = false)
+    private Boolean activo = true;
+}

--- a/src/main/java/com/ahumadamob/billeteraapi/enums/Moneda.java
+++ b/src/main/java/com/ahumadamob/billeteraapi/enums/Moneda.java
@@ -1,0 +1,16 @@
+package com.ahumadamob.billeteraapi.enums;
+
+/**
+ * Representa las monedas más utilizadas en Argentina.
+ */
+public enum Moneda {
+    ARS,
+    USD,
+    EUR,
+    BRL,
+    CLP,
+    UYU,
+    PYG,
+    BOB,
+    PEN
+}

--- a/src/main/java/com/ahumadamob/billeteraapi/repository/UsuarioRepository.java
+++ b/src/main/java/com/ahumadamob/billeteraapi/repository/UsuarioRepository.java
@@ -1,0 +1,11 @@
+package com.ahumadamob.billeteraapi.repository;
+
+import com.ahumadamob.billeteraapi.entity.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositorio JPA para la entidad {@link Usuario}.
+ */
+public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+}
+


### PR DESCRIPTION
## Summary
- add `Usuario` JPA entity with name, email, hashed password, base currency and active flag
- introduce `Moneda` enum for commonly used currencies in Argentina
- create `UsuarioRepository` for data access
- ensure table/column names mirror the entity and attributes, using underscores for camelCase fields

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.ahumadamob:billetera-api:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c62423dcbc832faee12d14deabd9aa