### PR TITLE
Add financial category management components

### DIFF
--- a/src/main/java/com/ahumadamob/fnanz/controller/CategoriaFinancieraController.java
+++ b/src/main/java/com/ahumadamob/fnanz/controller/CategoriaFinancieraController.java
@@ -1,0 +1,72 @@
+package com.ahumadamob.fnanz.controller;
+
+import com.ahumadamob.fnanz.dto.CategoriaFinancieraCreateDto;
+import com.ahumadamob.fnanz.dto.CategoriaFinancieraPatchDto;
+import com.ahumadamob.fnanz.dto.response.ApiResponseSuccessDto;
+import com.ahumadamob.fnanz.dto.response.CategoriaFinancieraResponseDto;
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import com.ahumadamob.fnanz.mapper.CategoriaFinancieraMapper;
+import com.ahumadamob.fnanz.service.CategoriaFinancieraService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.ahumadamob.fnanz.controller.ResponseFactory.*;
+
+/**
+ * Controlador REST para la gestión de categorías financieras.
+ */
+@RestController
+@RequestMapping("/api/categorias-financieras")
+public class CategoriaFinancieraController {
+
+    private final CategoriaFinancieraService categoriaFinancieraService;
+    private final CategoriaFinancieraMapper categoriaFinancieraMapper;
+
+    public CategoriaFinancieraController(CategoriaFinancieraService categoriaFinancieraService,
+                                         CategoriaFinancieraMapper categoriaFinancieraMapper) {
+        this.categoriaFinancieraService = categoriaFinancieraService;
+        this.categoriaFinancieraMapper = categoriaFinancieraMapper;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponseSuccessDto<CategoriaFinancieraResponseDto>> create(@Validated @RequestBody CategoriaFinancieraCreateDto dto) {
+        CategoriaFinanciera categoria = categoriaFinancieraMapper.toEntity(dto);
+        CategoriaFinanciera saved = categoriaFinancieraService.create(categoria);
+        CategoriaFinancieraResponseDto response = categoriaFinancieraMapper.toDto(saved);
+        return created(response.getId(), "Categoría financiera creada correctamente", response);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponseSuccessDto<List<CategoriaFinancieraResponseDto>>> list(@RequestParam(required = false) String q,
+                                                                                            Pageable pageable) {
+        Page<CategoriaFinanciera> page = categoriaFinancieraService.list(q, pageable);
+        Page<CategoriaFinancieraResponseDto> dtoPage = page.map(categoriaFinancieraMapper::toDto);
+        return page(dtoPage);
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponseSuccessDto<CategoriaFinancieraResponseDto> get(@PathVariable Long id) {
+        CategoriaFinanciera categoria = categoriaFinancieraService.get(id);
+        return ok(categoriaFinancieraMapper.toDto(categoria));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponseSuccessDto<CategoriaFinancieraResponseDto> update(@PathVariable Long id,
+                                                                        @Validated @RequestBody CategoriaFinancieraPatchDto dto) {
+        CategoriaFinanciera cambios = categoriaFinancieraMapper.toPartialEntity(dto);
+        CategoriaFinanciera updated = categoriaFinancieraService.update(id, cambios);
+        return ok(categoriaFinancieraMapper.toDto(updated));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        categoriaFinancieraService.delete(id);
+    }
+}

--- a/src/main/java/com/ahumadamob/fnanz/controller/GastoReservadoController.java
+++ b/src/main/java/com/ahumadamob/fnanz/controller/GastoReservadoController.java
@@ -1,0 +1,90 @@
+package com.ahumadamob.fnanz.controller;
+
+import com.ahumadamob.fnanz.dto.GastoReservadoCreateDto;
+import com.ahumadamob.fnanz.dto.GastoReservadoPatchDto;
+import com.ahumadamob.fnanz.dto.response.ApiResponseSuccessDto;
+import com.ahumadamob.fnanz.dto.response.GastoReservadoResponseDto;
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import com.ahumadamob.fnanz.entity.GastoReservado;
+import com.ahumadamob.fnanz.mapper.GastoReservadoMapper;
+import com.ahumadamob.fnanz.service.CategoriaFinancieraService;
+import com.ahumadamob.fnanz.service.GastoReservadoService;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.ahumadamob.fnanz.controller.ResponseFactory.*;
+
+/**
+ * Controlador REST para la gestión de gastos reservados.
+ */
+@RestController
+@RequestMapping("/api/gastos-reservados")
+public class GastoReservadoController {
+
+    private final GastoReservadoService gastoReservadoService;
+    private final CategoriaFinancieraService categoriaFinancieraService;
+    private final GastoReservadoMapper gastoReservadoMapper;
+
+    public GastoReservadoController(GastoReservadoService gastoReservadoService,
+                                    CategoriaFinancieraService categoriaFinancieraService,
+                                    GastoReservadoMapper gastoReservadoMapper) {
+        this.gastoReservadoService = gastoReservadoService;
+        this.categoriaFinancieraService = categoriaFinancieraService;
+        this.gastoReservadoMapper = gastoReservadoMapper;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponseSuccessDto<GastoReservadoResponseDto>> create(@Validated @RequestBody GastoReservadoCreateDto dto) {
+        CategoriaFinanciera categoria = categoriaFinancieraService.get(dto.getCategoriaId());
+        GastoReservado gasto = gastoReservadoMapper.toEntity(dto, categoria);
+        GastoReservado created = gastoReservadoService.create(gasto);
+        GastoReservadoResponseDto response = gastoReservadoMapper.toDto(created);
+        return created(response.getId(), "Gasto reservado creado correctamente", response);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponseSuccessDto<List<GastoReservadoResponseDto>>> list(@RequestParam(required = false) String q,
+                                                                                       Pageable pageable) {
+        Page<GastoReservado> page = gastoReservadoService.list(q, pageable);
+        Page<GastoReservadoResponseDto> dtoPage = page.map(gastoReservadoMapper::toDto);
+        return page(dtoPage);
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponseSuccessDto<GastoReservadoResponseDto> get(@PathVariable Long id) {
+        GastoReservado gasto = gastoReservadoService.get(id);
+        return ok(gastoReservadoMapper.toDto(gasto));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponseSuccessDto<GastoReservadoResponseDto> update(@PathVariable Long id,
+                                                                    @Validated @RequestBody GastoReservadoPatchDto dto) {
+        CategoriaFinanciera categoria = null;
+        if (dto.getCategoriaId() != null) {
+            categoria = categoriaFinancieraService.get(dto.getCategoriaId());
+        }
+        GastoReservado cambios = gastoReservadoMapper.toPartialEntity(dto, categoria);
+        GastoReservado updated = gastoReservadoService.update(id, cambios);
+        return ok(gastoReservadoMapper.toDto(updated));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        gastoReservadoService.delete(id);
+    }
+}

--- a/src/main/java/com/ahumadamob/fnanz/dto/CategoriaFinancieraCreateDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/CategoriaFinancieraCreateDto.java
@@ -1,0 +1,25 @@
+package com.ahumadamob.fnanz.dto;
+
+import com.ahumadamob.fnanz.enums.TipoFin;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO para la creación de categorías financieras.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class CategoriaFinancieraCreateDto {
+
+    private String nombre;
+
+    private TipoFin tipo;
+
+    private Boolean activo;
+
+    private Integer orden;
+
+    private String descripcion;
+}

--- a/src/main/java/com/ahumadamob/fnanz/dto/CategoriaFinancieraPatchDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/CategoriaFinancieraPatchDto.java
@@ -1,0 +1,25 @@
+package com.ahumadamob.fnanz.dto;
+
+import com.ahumadamob.fnanz.enums.TipoFin;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO para actualizaciones parciales de categorías financieras.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class CategoriaFinancieraPatchDto {
+
+    private String nombre;
+
+    private TipoFin tipo;
+
+    private Boolean activo;
+
+    private Integer orden;
+
+    private String descripcion;
+}

--- a/src/main/java/com/ahumadamob/fnanz/dto/GastoReservadoCreateDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/GastoReservadoCreateDto.java
@@ -1,0 +1,36 @@
+package com.ahumadamob.fnanz.dto;
+
+import com.ahumadamob.fnanz.enums.EstadoReserva;
+import com.ahumadamob.fnanz.enums.TipoFin;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO para la creación de gastos reservados.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class GastoReservadoCreateDto {
+
+    private TipoFin tipo;
+
+    private Long categoriaId;
+
+    private String concepto;
+
+    private LocalDate periodoFecha;
+
+    private LocalDate fechaVencimiento;
+
+    private EstadoReserva estado;
+
+    private BigDecimal montoReservado;
+
+    private BigDecimal montoAplicado;
+
+    private String nota;
+}

--- a/src/main/java/com/ahumadamob/fnanz/dto/GastoReservadoPatchDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/GastoReservadoPatchDto.java
@@ -1,0 +1,36 @@
+package com.ahumadamob.fnanz.dto;
+
+import com.ahumadamob.fnanz.enums.EstadoReserva;
+import com.ahumadamob.fnanz.enums.TipoFin;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO para actualizaciones parciales de gastos reservados.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class GastoReservadoPatchDto {
+
+    private TipoFin tipo;
+
+    private Long categoriaId;
+
+    private String concepto;
+
+    private LocalDate periodoFecha;
+
+    private LocalDate fechaVencimiento;
+
+    private EstadoReserva estado;
+
+    private BigDecimal montoReservado;
+
+    private BigDecimal montoAplicado;
+
+    private String nota;
+}

--- a/src/main/java/com/ahumadamob/fnanz/dto/response/CategoriaFinancieraResponseDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/CategoriaFinancieraResponseDto.java
@@ -1,0 +1,35 @@
+package com.ahumadamob.fnanz.dto.response;
+
+import com.ahumadamob.fnanz.enums.TipoFin;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * DTO de lectura de categorías financieras.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoriaFinancieraResponseDto {
+
+    private Long id;
+
+    private String nombre;
+
+    private TipoFin tipo;
+
+    private boolean activo;
+
+    private Integer orden;
+
+    private String descripcion;
+
+    private LocalDateTime creadoEn;
+
+    private LocalDateTime actualizadoEn;
+}

--- a/src/main/java/com/ahumadamob/fnanz/dto/response/GastoReservadoResponseDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/GastoReservadoResponseDto.java
@@ -1,0 +1,47 @@
+package com.ahumadamob.fnanz.dto.response;
+
+import com.ahumadamob.fnanz.enums.EstadoReserva;
+import com.ahumadamob.fnanz.enums.TipoFin;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO de lectura de gastos reservados.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GastoReservadoResponseDto {
+
+    private Long id;
+
+    private TipoFin tipo;
+
+    private Long categoriaId;
+
+    private String categoriaNombre;
+
+    private String concepto;
+
+    private LocalDate periodoFecha;
+
+    private LocalDate fechaVencimiento;
+
+    private EstadoReserva estado;
+
+    private BigDecimal montoReservado;
+
+    private BigDecimal montoAplicado;
+
+    private String nota;
+
+    private LocalDateTime creadoEn;
+
+    private LocalDateTime actualizadoEn;
+}

--- a/src/main/java/com/ahumadamob/fnanz/entity/CategoriaFinanciera.java
+++ b/src/main/java/com/ahumadamob/fnanz/entity/CategoriaFinanciera.java
@@ -1,0 +1,44 @@
+package com.ahumadamob.fnanz.entity;
+
+import com.ahumadamob.fnanz.enums.TipoFin;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Representa una categoría financiera para clasificar ingresos y egresos.
+ */
+@Entity
+@Table(name = "categoria_financiera")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CategoriaFinanciera extends BaseEntity {
+
+    @NotBlank
+    @Size(max = 100)
+    @Column(name = "nombre", nullable = false, length = 100, unique = true)
+    private String nombre;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo", nullable = false, length = 10)
+    private TipoFin tipo;
+
+    @Column(name = "activo", nullable = false)
+    private Boolean activo = true;
+
+    @Column(name = "orden")
+    private Integer orden;
+
+    @Column(name = "descripcion", columnDefinition = "text")
+    private String descripcion;
+}

--- a/src/main/java/com/ahumadamob/fnanz/entity/GastoReservado.java
+++ b/src/main/java/com/ahumadamob/fnanz/entity/GastoReservado.java
@@ -1,0 +1,75 @@
+package com.ahumadamob.fnanz.entity;
+
+import com.ahumadamob.fnanz.enums.EstadoReserva;
+import com.ahumadamob.fnanz.enums.TipoFin;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Representa una reserva de gasto/ingreso planificado.
+ */
+@Entity
+@Table(name = "gasto_reservado")
+@Getter
+@Setter
+@NoArgsConstructor
+public class GastoReservado extends BaseEntity {
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo", nullable = false, length = 10)
+    private TipoFin tipo;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "categoria_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_reserva_categoria"))
+    private CategoriaFinanciera categoria;
+
+    @Size(max = 120)
+    @Column(name = "concepto", length = 120)
+    private String concepto;
+
+    /** Usar el 1er día del mes como convención de periodo */
+    @NotNull
+    @Column(name = "periodo_fecha", nullable = false)
+    private LocalDate periodoFecha;
+
+    @Column(name = "fecha_vencimiento")
+    private LocalDate fechaVencimiento;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado", nullable = false, length = 12)
+    private EstadoReserva estado = EstadoReserva.RESERVADO;
+
+    @NotNull
+    @DecimalMin(value = "0.00")
+    @Digits(integer = 14, fraction = 2)
+    @Column(name = "monto_reservado", nullable = false, precision = 14, scale = 2)
+    private BigDecimal montoReservado;
+
+    @DecimalMin(value = "0.00")
+    @Digits(integer = 14, fraction = 2)
+    @Column(name = "monto_aplicado", precision = 14, scale = 2)
+    private BigDecimal montoAplicado;
+
+    @Column(name = "nota", columnDefinition = "text")
+    private String nota;
+}

--- a/src/main/java/com/ahumadamob/fnanz/enums/EstadoReserva.java
+++ b/src/main/java/com/ahumadamob/fnanz/enums/EstadoReserva.java
@@ -1,0 +1,10 @@
+package com.ahumadamob.fnanz.enums;
+
+/**
+ * Estados posibles para una reserva de gasto.
+ */
+public enum EstadoReserva {
+    RESERVADO,
+    APLICADO,
+    CANCELADO
+}

--- a/src/main/java/com/ahumadamob/fnanz/enums/TipoFin.java
+++ b/src/main/java/com/ahumadamob/fnanz/enums/TipoFin.java
@@ -1,0 +1,9 @@
+package com.ahumadamob.fnanz.enums;
+
+/**
+ * Tipo de movimiento financiero que representa una categoría.
+ */
+public enum TipoFin {
+    INGRESO,
+    EGRESO
+}

--- a/src/main/java/com/ahumadamob/fnanz/mapper/CategoriaFinancieraMapper.java
+++ b/src/main/java/com/ahumadamob/fnanz/mapper/CategoriaFinancieraMapper.java
@@ -1,0 +1,53 @@
+package com.ahumadamob.fnanz.mapper;
+
+import com.ahumadamob.fnanz.dto.CategoriaFinancieraCreateDto;
+import com.ahumadamob.fnanz.dto.CategoriaFinancieraPatchDto;
+import com.ahumadamob.fnanz.dto.response.CategoriaFinancieraResponseDto;
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Especialista en transformar DTOs de CategoriaFinanciera a entidades y viceversa.
+ */
+@Component
+public class CategoriaFinancieraMapper {
+
+    public CategoriaFinanciera toEntity(CategoriaFinancieraCreateDto dto) {
+        CategoriaFinanciera categoria = new CategoriaFinanciera();
+        categoria.setNombre(dto.getNombre());
+        categoria.setTipo(dto.getTipo());
+        Optional.ofNullable(dto.getActivo()).ifPresent(categoria::setActivo);
+        categoria.setOrden(dto.getOrden());
+        categoria.setDescripcion(dto.getDescripcion());
+        return categoria;
+    }
+
+    public CategoriaFinanciera toPartialEntity(CategoriaFinancieraPatchDto dto) {
+        CategoriaFinanciera categoria = new CategoriaFinanciera();
+        updateEntity(dto, categoria);
+        return categoria;
+    }
+
+    public void updateEntity(CategoriaFinancieraPatchDto dto, CategoriaFinanciera categoria) {
+        Optional.ofNullable(dto.getNombre()).ifPresent(categoria::setNombre);
+        Optional.ofNullable(dto.getTipo()).ifPresent(categoria::setTipo);
+        Optional.ofNullable(dto.getActivo()).ifPresent(categoria::setActivo);
+        Optional.ofNullable(dto.getOrden()).ifPresent(categoria::setOrden);
+        Optional.ofNullable(dto.getDescripcion()).ifPresent(categoria::setDescripcion);
+    }
+
+    public CategoriaFinancieraResponseDto toDto(CategoriaFinanciera categoria) {
+        return new CategoriaFinancieraResponseDto(
+                categoria.getId(),
+                categoria.getNombre(),
+                categoria.getTipo(),
+                Boolean.TRUE.equals(categoria.getActivo()),
+                categoria.getOrden(),
+                categoria.getDescripcion(),
+                categoria.getCreatedAt(),
+                categoria.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ahumadamob/fnanz/mapper/GastoReservadoMapper.java
+++ b/src/main/java/com/ahumadamob/fnanz/mapper/GastoReservadoMapper.java
@@ -1,0 +1,70 @@
+package com.ahumadamob.fnanz.mapper;
+
+import com.ahumadamob.fnanz.dto.GastoReservadoCreateDto;
+import com.ahumadamob.fnanz.dto.GastoReservadoPatchDto;
+import com.ahumadamob.fnanz.dto.response.GastoReservadoResponseDto;
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import com.ahumadamob.fnanz.entity.GastoReservado;
+import com.ahumadamob.fnanz.enums.EstadoReserva;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Especialista en transformar DTOs de GastoReservado a entidades y viceversa.
+ */
+@Component
+public class GastoReservadoMapper {
+
+    public GastoReservado toEntity(GastoReservadoCreateDto dto, CategoriaFinanciera categoria) {
+        GastoReservado gasto = new GastoReservado();
+        gasto.setTipo(dto.getTipo());
+        gasto.setCategoria(categoria);
+        gasto.setConcepto(dto.getConcepto());
+        gasto.setPeriodoFecha(dto.getPeriodoFecha());
+        gasto.setFechaVencimiento(dto.getFechaVencimiento());
+        gasto.setEstado(Optional.ofNullable(dto.getEstado()).orElse(EstadoReserva.RESERVADO));
+        gasto.setMontoReservado(dto.getMontoReservado());
+        gasto.setMontoAplicado(dto.getMontoAplicado());
+        gasto.setNota(dto.getNota());
+        return gasto;
+    }
+
+    public GastoReservado toPartialEntity(GastoReservadoPatchDto dto, CategoriaFinanciera categoria) {
+        GastoReservado gasto = new GastoReservado();
+        updateEntity(dto, gasto, categoria);
+        return gasto;
+    }
+
+    public void updateEntity(GastoReservadoPatchDto dto, GastoReservado gasto, CategoriaFinanciera categoria) {
+        Optional.ofNullable(dto.getTipo()).ifPresent(gasto::setTipo);
+        if (categoria != null) {
+            gasto.setCategoria(categoria);
+        }
+        Optional.ofNullable(dto.getConcepto()).ifPresent(gasto::setConcepto);
+        Optional.ofNullable(dto.getPeriodoFecha()).ifPresent(gasto::setPeriodoFecha);
+        Optional.ofNullable(dto.getFechaVencimiento()).ifPresent(gasto::setFechaVencimiento);
+        Optional.ofNullable(dto.getEstado()).ifPresent(gasto::setEstado);
+        Optional.ofNullable(dto.getMontoReservado()).ifPresent(gasto::setMontoReservado);
+        Optional.ofNullable(dto.getMontoAplicado()).ifPresent(gasto::setMontoAplicado);
+        Optional.ofNullable(dto.getNota()).ifPresent(gasto::setNota);
+    }
+
+    public GastoReservadoResponseDto toDto(GastoReservado gasto) {
+        CategoriaFinanciera categoria = gasto.getCategoria();
+        return new GastoReservadoResponseDto(
+                gasto.getId(),
+                gasto.getTipo(),
+                categoria != null ? categoria.getId() : null,
+                categoria != null ? categoria.getNombre() : null,
+                gasto.getConcepto(),
+                gasto.getPeriodoFecha(),
+                gasto.getFechaVencimiento(),
+                gasto.getEstado(),
+                gasto.getMontoReservado(),
+                gasto.getMontoAplicado(),
+                gasto.getNota(),
+                gasto.getCreatedAt(),
+                gasto.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ahumadamob/fnanz/repository/CategoriaFinancieraRepository.java
+++ b/src/main/java/com/ahumadamob/fnanz/repository/CategoriaFinancieraRepository.java
@@ -1,0 +1,15 @@
+package com.ahumadamob.fnanz.repository;
+
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.Optional;
+
+/**
+ * Repositorio JPA para la entidad {@link CategoriaFinanciera}.
+ */
+public interface CategoriaFinancieraRepository extends JpaRepository<CategoriaFinanciera, Long>,
+        JpaSpecificationExecutor<CategoriaFinanciera> {
+    Optional<CategoriaFinanciera> findByNombre(String nombre);
+}

--- a/src/main/java/com/ahumadamob/fnanz/repository/GastoReservadoRepository.java
+++ b/src/main/java/com/ahumadamob/fnanz/repository/GastoReservadoRepository.java
@@ -1,0 +1,12 @@
+package com.ahumadamob.fnanz.repository;
+
+import com.ahumadamob.fnanz.entity.GastoReservado;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+/**
+ * Repositorio JPA para la entidad {@link GastoReservado}.
+ */
+public interface GastoReservadoRepository extends JpaRepository<GastoReservado, Long>,
+        JpaSpecificationExecutor<GastoReservado> {
+}

--- a/src/main/java/com/ahumadamob/fnanz/service/CategoriaFinancieraService.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/CategoriaFinancieraService.java
@@ -1,0 +1,16 @@
+package com.ahumadamob.fnanz.service;
+
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Servicio para operaciones de {@link com.ahumadamob.fnanz.entity.CategoriaFinanciera}.
+ */
+public interface CategoriaFinancieraService {
+    CategoriaFinanciera create(CategoriaFinanciera categoria);
+    Page<CategoriaFinanciera> list(String q, Pageable pageable);
+    CategoriaFinanciera get(Long id);
+    CategoriaFinanciera update(Long id, CategoriaFinanciera categoria);
+    void delete(Long id);
+}

--- a/src/main/java/com/ahumadamob/fnanz/service/GastoReservadoService.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/GastoReservadoService.java
@@ -1,0 +1,16 @@
+package com.ahumadamob.fnanz.service;
+
+import com.ahumadamob.fnanz.entity.GastoReservado;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Servicio para operaciones de {@link com.ahumadamob.fnanz.entity.GastoReservado}.
+ */
+public interface GastoReservadoService {
+    GastoReservado create(GastoReservado gastoReservado);
+    Page<GastoReservado> list(String q, Pageable pageable);
+    GastoReservado get(Long id);
+    GastoReservado update(Long id, GastoReservado gastoReservado);
+    void delete(Long id);
+}

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/CategoriaFinancieraServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/CategoriaFinancieraServiceImpl.java
@@ -36,14 +36,15 @@ public class CategoriaFinancieraServiceImpl implements CategoriaFinancieraServic
     @Override
     @Transactional(readOnly = true)
     public Page<CategoriaFinanciera> list(String q, Pageable pageable) {
-        Specification<CategoriaFinanciera> spec = Specification.where(null);
-        if (q != null && !q.isBlank()) {
-            String like = "%" + q.toLowerCase() + "%";
-            spec = spec.and((root, query, cb) -> cb.or(
-                    cb.like(cb.lower(root.get("nombre")), like),
-                    cb.like(cb.lower(cb.coalesce(root.get("descripcion"), "")), like)
-            ));
+        if (q == null || q.isBlank()) {
+            return categoriaFinancieraRepository.findAll(pageable);
         }
+
+        String like = "%" + q.toLowerCase() + "%";
+        Specification<CategoriaFinanciera> spec = (root, query, cb) -> cb.or(
+                cb.like(cb.lower(root.get("nombre")), like),
+                cb.like(cb.lower(cb.coalesce(root.get("descripcion"), "")), like)
+        );
         return categoriaFinancieraRepository.findAll(spec, pageable);
     }
 

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/CategoriaFinancieraServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/CategoriaFinancieraServiceImpl.java
@@ -1,0 +1,91 @@
+package com.ahumadamob.fnanz.service.jpa;
+
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import com.ahumadamob.fnanz.error.ResourceConflictException;
+import com.ahumadamob.fnanz.error.ResourceNotFoundException;
+import com.ahumadamob.fnanz.repository.CategoriaFinancieraRepository;
+import com.ahumadamob.fnanz.service.CategoriaFinancieraService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Implementación JPA del servicio de categorías financieras.
+ */
+@Service
+@Transactional
+public class CategoriaFinancieraServiceImpl implements CategoriaFinancieraService {
+
+    private final CategoriaFinancieraRepository categoriaFinancieraRepository;
+
+    public CategoriaFinancieraServiceImpl(CategoriaFinancieraRepository categoriaFinancieraRepository) {
+        this.categoriaFinancieraRepository = categoriaFinancieraRepository;
+    }
+
+    @Override
+    public CategoriaFinanciera create(CategoriaFinanciera categoria) {
+        categoriaFinancieraRepository.findByNombre(categoria.getNombre())
+                .ifPresent(existing -> {
+                    throw new ResourceConflictException("nombre", "El nombre ya está en uso");
+                });
+        return categoriaFinancieraRepository.save(categoria);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CategoriaFinanciera> list(String q, Pageable pageable) {
+        Specification<CategoriaFinanciera> spec = Specification.where(null);
+        if (q != null && !q.isBlank()) {
+            String like = "%" + q.toLowerCase() + "%";
+            spec = spec.and((root, query, cb) -> cb.or(
+                    cb.like(cb.lower(root.get("nombre")), like),
+                    cb.like(cb.lower(cb.coalesce(root.get("descripcion"), "")), like)
+            ));
+        }
+        return categoriaFinancieraRepository.findAll(spec, pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CategoriaFinanciera get(Long id) {
+        return categoriaFinancieraRepository.findById(id)
+                .orElseThrow(ResourceNotFoundException::new);
+    }
+
+    @Override
+    public CategoriaFinanciera update(Long id, CategoriaFinanciera cambios) {
+        CategoriaFinanciera categoria = categoriaFinancieraRepository.findById(id)
+                .orElseThrow(ResourceNotFoundException::new);
+        if (cambios.getNombre() != null && !cambios.getNombre().equals(categoria.getNombre())) {
+            categoriaFinancieraRepository.findByNombre(cambios.getNombre())
+                    .filter(existing -> !existing.getId().equals(id))
+                    .ifPresent(existing -> {
+                        throw new ResourceConflictException("nombre", "El nombre ya está en uso");
+                    });
+            categoria.setNombre(cambios.getNombre());
+        }
+        if (cambios.getTipo() != null) {
+            categoria.setTipo(cambios.getTipo());
+        }
+        if (cambios.getActivo() != null) {
+            categoria.setActivo(cambios.getActivo());
+        }
+        if (cambios.getOrden() != null) {
+            categoria.setOrden(cambios.getOrden());
+        }
+        if (cambios.getDescripcion() != null) {
+            categoria.setDescripcion(cambios.getDescripcion());
+        }
+        return categoriaFinancieraRepository.save(categoria);
+    }
+
+    @Override
+    public void delete(Long id) {
+        if (!categoriaFinancieraRepository.existsById(id)) {
+            throw new ResourceNotFoundException();
+        }
+        categoriaFinancieraRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImpl.java
@@ -1,0 +1,113 @@
+package com.ahumadamob.fnanz.service.jpa;
+
+import com.ahumadamob.fnanz.entity.GastoReservado;
+import com.ahumadamob.fnanz.error.ResourceConflictException;
+import com.ahumadamob.fnanz.error.ResourceNotFoundException;
+import com.ahumadamob.fnanz.repository.GastoReservadoRepository;
+import com.ahumadamob.fnanz.service.GastoReservadoService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Implementación JPA del servicio de gastos reservados.
+ */
+@Service
+@Transactional
+public class GastoReservadoServiceImpl implements GastoReservadoService {
+
+    private final GastoReservadoRepository gastoReservadoRepository;
+
+    public GastoReservadoServiceImpl(GastoReservadoRepository gastoReservadoRepository) {
+        this.gastoReservadoRepository = gastoReservadoRepository;
+    }
+
+    @Override
+    public GastoReservado create(GastoReservado gastoReservado) {
+        validateCategoriaAndTipo(gastoReservado);
+        return gastoReservadoRepository.save(gastoReservado);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<GastoReservado> list(String q, Pageable pageable) {
+        if (q == null || q.isBlank()) {
+            return gastoReservadoRepository.findAll(pageable);
+        }
+        String like = "%" + q.toLowerCase() + "%";
+        Specification<GastoReservado> spec = (root, query, cb) -> {
+            var categoriaJoin = root.join("categoria");
+            return cb.or(
+                    cb.like(cb.lower(cb.coalesce(root.get("concepto"), "")), like),
+                    cb.like(cb.lower(cb.coalesce(root.get("nota"), "")), like),
+                    cb.like(cb.lower(categoriaJoin.get("nombre")), like)
+            );
+        };
+        return gastoReservadoRepository.findAll(spec, pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GastoReservado get(Long id) {
+        return gastoReservadoRepository.findById(id)
+                .orElseThrow(ResourceNotFoundException::new);
+    }
+
+    @Override
+    public GastoReservado update(Long id, GastoReservado cambios) {
+        GastoReservado gasto = gastoReservadoRepository.findById(id)
+                .orElseThrow(ResourceNotFoundException::new);
+
+        if (cambios.getTipo() != null) {
+            gasto.setTipo(cambios.getTipo());
+        }
+        if (cambios.getCategoria() != null) {
+            gasto.setCategoria(cambios.getCategoria());
+        }
+        if (cambios.getConcepto() != null) {
+            gasto.setConcepto(cambios.getConcepto());
+        }
+        if (cambios.getPeriodoFecha() != null) {
+            gasto.setPeriodoFecha(cambios.getPeriodoFecha());
+        }
+        if (cambios.getFechaVencimiento() != null) {
+            gasto.setFechaVencimiento(cambios.getFechaVencimiento());
+        }
+        if (cambios.getEstado() != null) {
+            gasto.setEstado(cambios.getEstado());
+        }
+        if (cambios.getMontoReservado() != null) {
+            gasto.setMontoReservado(cambios.getMontoReservado());
+        }
+        if (cambios.getMontoAplicado() != null) {
+            gasto.setMontoAplicado(cambios.getMontoAplicado());
+        }
+        if (cambios.getNota() != null) {
+            gasto.setNota(cambios.getNota());
+        }
+
+        validateCategoriaAndTipo(gasto);
+        return gastoReservadoRepository.save(gasto);
+    }
+
+    @Override
+    public void delete(Long id) {
+        if (!gastoReservadoRepository.existsById(id)) {
+            throw new ResourceNotFoundException();
+        }
+        gastoReservadoRepository.deleteById(id);
+    }
+
+    private void validateCategoriaAndTipo(GastoReservado gastoReservado) {
+        if (gastoReservado.getCategoria() == null) {
+            throw new ResourceConflictException("categoriaId", "La categoría asociada no es válida");
+        }
+        if (gastoReservado.getTipo() != null
+                && gastoReservado.getCategoria().getTipo() != null
+                && gastoReservado.getTipo() != gastoReservado.getCategoria().getTipo()) {
+            throw new ResourceConflictException("tipo", "El tipo no coincide con la categoría asociada");
+        }
+    }
+}

--- a/src/test/java/com/ahumadamob/fnanz/controller/CategoriaFinancieraControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/CategoriaFinancieraControllerTest.java
@@ -1,0 +1,271 @@
+package com.ahumadamob.fnanz.controller;
+
+import com.ahumadamob.fnanz.dto.CategoriaFinancieraCreateDto;
+import com.ahumadamob.fnanz.dto.CategoriaFinancieraPatchDto;
+import com.ahumadamob.fnanz.dto.response.CategoriaFinancieraResponseDto;
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import com.ahumadamob.fnanz.enums.TipoFin;
+import com.ahumadamob.fnanz.mapper.CategoriaFinancieraMapper;
+import com.ahumadamob.fnanz.service.CategoriaFinancieraService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CategoriaFinancieraController.class)
+class CategoriaFinancieraControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CategoriaFinancieraService categoriaFinancieraService;
+
+    @MockBean
+    private CategoriaFinancieraMapper categoriaFinancieraMapper;
+
+    @Test
+    void createShouldReturnCreatedResponseWithLocationHeader() throws Exception {
+        CategoriaFinancieraCreateDto requestDto = new CategoriaFinancieraCreateDto();
+        requestDto.setNombre("Salario");
+        requestDto.setTipo(TipoFin.INGRESO);
+        requestDto.setActivo(true);
+        requestDto.setOrden(1);
+        requestDto.setDescripcion("Ingreso mensual");
+
+        CategoriaFinanciera entityToCreate = new CategoriaFinanciera();
+        entityToCreate.setNombre("Salario");
+        entityToCreate.setTipo(TipoFin.INGRESO);
+        entityToCreate.setActivo(true);
+        entityToCreate.setOrden(1);
+        entityToCreate.setDescripcion("Ingreso mensual");
+
+        LocalDateTime now = LocalDateTime.of(2024, 5, 1, 10, 0);
+        CategoriaFinanciera savedEntity = new CategoriaFinanciera();
+        savedEntity.setId(42L);
+        savedEntity.setNombre("Salario");
+        savedEntity.setTipo(TipoFin.INGRESO);
+        savedEntity.setActivo(true);
+        savedEntity.setOrden(1);
+        savedEntity.setDescripcion("Ingreso mensual");
+        savedEntity.setCreatedAt(now);
+        savedEntity.setUpdatedAt(now);
+
+        CategoriaFinancieraResponseDto responseDto = new CategoriaFinancieraResponseDto(
+                42L,
+                "Salario",
+                TipoFin.INGRESO,
+                true,
+                1,
+                "Ingreso mensual",
+                now,
+                now
+        );
+
+        when(categoriaFinancieraMapper.toEntity(ArgumentMatchers.any(CategoriaFinancieraCreateDto.class)))
+                .thenReturn(entityToCreate);
+        when(categoriaFinancieraService.create(entityToCreate)).thenReturn(savedEntity);
+        when(categoriaFinancieraMapper.toDto(savedEntity)).thenReturn(responseDto);
+
+        mockMvc.perform(post("/api/categorias-financieras")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "http://localhost/api/categorias-financieras/42"))
+                .andExpect(jsonPath("$.message").value("Categoría financiera creada correctamente"))
+                .andExpect(jsonPath("$.data.id").value(42L))
+                .andExpect(jsonPath("$.data.nombre").value("Salario"))
+                .andExpect(jsonPath("$.data.tipo").value(TipoFin.INGRESO.name()))
+                .andExpect(jsonPath("$.data.activo").value(true))
+                .andExpect(jsonPath("$.data.orden").value(1))
+                .andExpect(jsonPath("$.data.descripcion").value("Ingreso mensual"))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(categoriaFinancieraMapper).toEntity(ArgumentMatchers.any(CategoriaFinancieraCreateDto.class));
+        verify(categoriaFinancieraService).create(entityToCreate);
+        verify(categoriaFinancieraMapper).toDto(savedEntity);
+        verifyNoMoreInteractions(categoriaFinancieraService, categoriaFinancieraMapper);
+    }
+
+    @Test
+    void listShouldReturnPagedResponseWithHeaders() throws Exception {
+        CategoriaFinanciera ingreso = new CategoriaFinanciera();
+        ingreso.setId(1L);
+        ingreso.setNombre("Salario");
+        ingreso.setTipo(TipoFin.INGRESO);
+
+        CategoriaFinanciera egreso = new CategoriaFinanciera();
+        egreso.setId(2L);
+        egreso.setNombre("Alquiler");
+        egreso.setTipo(TipoFin.EGRESO);
+
+        CategoriaFinancieraResponseDto ingresoDto = new CategoriaFinancieraResponseDto(
+                1L,
+                "Salario",
+                TipoFin.INGRESO,
+                true,
+                1,
+                "Ingreso mensual",
+                null,
+                null
+        );
+        CategoriaFinancieraResponseDto egresoDto = new CategoriaFinancieraResponseDto(
+                2L,
+                "Alquiler",
+                TipoFin.EGRESO,
+                true,
+                2,
+                "Gasto fijo",
+                null,
+                null
+        );
+
+        Page<CategoriaFinanciera> page = new PageImpl<>(List.of(ingreso, egreso), PageRequest.of(0, 2), 4);
+
+        when(categoriaFinancieraService.list(ArgumentMatchers.isNull(), ArgumentMatchers.any(Pageable.class)))
+                .thenReturn(page);
+        when(categoriaFinancieraMapper.toDto(ingreso)).thenReturn(ingresoDto);
+        when(categoriaFinancieraMapper.toDto(egreso)).thenReturn(egresoDto);
+
+        mockMvc.perform(get("/api/categorias-financieras")
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Total-Count", "4"))
+                .andExpect(header().string(HttpHeaders.LINK, containsString("rel=\"next\"")))
+                .andExpect(header().string(HttpHeaders.LINK, containsString("rel=\"last\"")))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].id").value(1L))
+                .andExpect(jsonPath("$.data[0].nombre").value("Salario"))
+                .andExpect(jsonPath("$.data[0].tipo").value(TipoFin.INGRESO.name()))
+                .andExpect(jsonPath("$.data[1].id").value(2L))
+                .andExpect(jsonPath("$.data[1].tipo").value(TipoFin.EGRESO.name()))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(categoriaFinancieraService).list(ArgumentMatchers.isNull(), ArgumentMatchers.any(Pageable.class));
+        verify(categoriaFinancieraMapper).toDto(ingreso);
+        verify(categoriaFinancieraMapper).toDto(egreso);
+        verifyNoMoreInteractions(categoriaFinancieraService, categoriaFinancieraMapper);
+    }
+
+    @Test
+    void getShouldReturnExistingCategoria() throws Exception {
+        CategoriaFinanciera categoria = new CategoriaFinanciera();
+        categoria.setId(10L);
+        categoria.setNombre("Consultoría");
+        categoria.setTipo(TipoFin.INGRESO);
+
+        CategoriaFinancieraResponseDto dto = new CategoriaFinancieraResponseDto(
+                10L,
+                "Consultoría",
+                TipoFin.INGRESO,
+                true,
+                3,
+                "Servicios profesionales",
+                null,
+                null
+        );
+
+        when(categoriaFinancieraService.get(10L)).thenReturn(categoria);
+        when(categoriaFinancieraMapper.toDto(categoria)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/categorias-financieras/{id}", 10L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(10L))
+                .andExpect(jsonPath("$.data.nombre").value("Consultoría"))
+                .andExpect(jsonPath("$.data.tipo").value(TipoFin.INGRESO.name()))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(categoriaFinancieraService).get(10L);
+        verify(categoriaFinancieraMapper).toDto(categoria);
+        verifyNoMoreInteractions(categoriaFinancieraService, categoriaFinancieraMapper);
+    }
+
+    @Test
+    void updateShouldReturnUpdatedCategoria() throws Exception {
+        CategoriaFinancieraPatchDto patchDto = new CategoriaFinancieraPatchDto();
+        patchDto.setNombre("Dividendos");
+        patchDto.setActivo(false);
+
+        CategoriaFinanciera cambios = new CategoriaFinanciera();
+        cambios.setNombre("Dividendos");
+        cambios.setActivo(false);
+
+        CategoriaFinanciera updated = new CategoriaFinanciera();
+        updated.setId(7L);
+        updated.setNombre("Dividendos");
+        updated.setTipo(TipoFin.INGRESO);
+        updated.setActivo(false);
+
+        CategoriaFinancieraResponseDto responseDto = new CategoriaFinancieraResponseDto(
+                7L,
+                "Dividendos",
+                TipoFin.INGRESO,
+                false,
+                null,
+                null,
+                null,
+                null
+        );
+
+        when(categoriaFinancieraMapper.toPartialEntity(ArgumentMatchers.any(CategoriaFinancieraPatchDto.class)))
+                .thenReturn(cambios);
+        when(categoriaFinancieraService.update(7L, cambios)).thenReturn(updated);
+        when(categoriaFinancieraMapper.toDto(updated)).thenReturn(responseDto);
+
+        mockMvc.perform(patch("/api/categorias-financieras/{id}", 7L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(patchDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(7L))
+                .andExpect(jsonPath("$.data.nombre").value("Dividendos"))
+                .andExpect(jsonPath("$.data.activo").value(false))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(categoriaFinancieraMapper).toPartialEntity(ArgumentMatchers.any(CategoriaFinancieraPatchDto.class));
+        verify(categoriaFinancieraService).update(7L, cambios);
+        verify(categoriaFinancieraMapper).toDto(updated);
+        verifyNoMoreInteractions(categoriaFinancieraService, categoriaFinancieraMapper);
+    }
+
+    @Test
+    void deleteShouldReturnNoContent() throws Exception {
+        doNothing().when(categoriaFinancieraService).delete(99L);
+
+        mockMvc.perform(delete("/api/categorias-financieras/{id}", 99L))
+                .andExpect(status().isNoContent());
+
+        verify(categoriaFinancieraService).delete(99L);
+        verifyNoMoreInteractions(categoriaFinancieraService);
+    }
+}

--- a/src/test/java/com/ahumadamob/fnanz/controller/GastoReservadoControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/GastoReservadoControllerTest.java
@@ -1,0 +1,340 @@
+package com.ahumadamob.fnanz.controller;
+
+import com.ahumadamob.fnanz.dto.GastoReservadoCreateDto;
+import com.ahumadamob.fnanz.dto.GastoReservadoPatchDto;
+import com.ahumadamob.fnanz.dto.response.GastoReservadoResponseDto;
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import com.ahumadamob.fnanz.entity.GastoReservado;
+import com.ahumadamob.fnanz.enums.EstadoReserva;
+import com.ahumadamob.fnanz.enums.TipoFin;
+import com.ahumadamob.fnanz.mapper.GastoReservadoMapper;
+import com.ahumadamob.fnanz.service.CategoriaFinancieraService;
+import com.ahumadamob.fnanz.service.GastoReservadoService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = GastoReservadoController.class)
+class GastoReservadoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private GastoReservadoService gastoReservadoService;
+
+    @MockBean
+    private CategoriaFinancieraService categoriaFinancieraService;
+
+    @MockBean
+    private GastoReservadoMapper gastoReservadoMapper;
+
+    @Test
+    void createShouldReturnCreatedResponseWithLocationHeader() throws Exception {
+        GastoReservadoCreateDto requestDto = new GastoReservadoCreateDto();
+        requestDto.setTipo(TipoFin.EGRESO);
+        requestDto.setCategoriaId(5L);
+        requestDto.setConcepto("Pago consultoría");
+        requestDto.setPeriodoFecha(LocalDate.of(2024, 5, 1));
+        requestDto.setFechaVencimiento(LocalDate.of(2024, 5, 10));
+        requestDto.setEstado(EstadoReserva.RESERVADO);
+        requestDto.setMontoReservado(new BigDecimal("1500.00"));
+        requestDto.setMontoAplicado(new BigDecimal("0.00"));
+        requestDto.setNota("Mensual");
+
+        CategoriaFinanciera categoria = new CategoriaFinanciera();
+        categoria.setId(5L);
+        categoria.setNombre("Servicios");
+        categoria.setTipo(TipoFin.EGRESO);
+
+        GastoReservado entityToCreate = new GastoReservado();
+        entityToCreate.setTipo(TipoFin.EGRESO);
+        entityToCreate.setCategoria(categoria);
+        entityToCreate.setConcepto("Pago consultoría");
+
+        LocalDateTime now = LocalDateTime.of(2024, 5, 2, 12, 0);
+        GastoReservado saved = new GastoReservado();
+        saved.setId(11L);
+        saved.setTipo(TipoFin.EGRESO);
+        saved.setCategoria(categoria);
+        saved.setConcepto("Pago consultoría");
+        saved.setPeriodoFecha(LocalDate.of(2024, 5, 1));
+        saved.setEstado(EstadoReserva.RESERVADO);
+        saved.setMontoReservado(new BigDecimal("1500.00"));
+        saved.setMontoAplicado(BigDecimal.ZERO);
+        saved.setNota("Mensual");
+        saved.setCreatedAt(now);
+        saved.setUpdatedAt(now);
+
+        GastoReservadoResponseDto responseDto = new GastoReservadoResponseDto(
+                11L,
+                TipoFin.EGRESO,
+                5L,
+                "Servicios",
+                "Pago consultoría",
+                LocalDate.of(2024, 5, 1),
+                LocalDate.of(2024, 5, 10),
+                EstadoReserva.RESERVADO,
+                new BigDecimal("1500.00"),
+                BigDecimal.ZERO,
+                "Mensual",
+                now,
+                now
+        );
+
+        when(categoriaFinancieraService.get(5L)).thenReturn(categoria);
+        when(gastoReservadoMapper.toEntity(ArgumentMatchers.any(GastoReservadoCreateDto.class), eq(categoria)))
+                .thenReturn(entityToCreate);
+        when(gastoReservadoService.create(entityToCreate)).thenReturn(saved);
+        when(gastoReservadoMapper.toDto(saved)).thenReturn(responseDto);
+
+        mockMvc.perform(post("/api/gastos-reservados")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "http://localhost/api/gastos-reservados/11"))
+                .andExpect(jsonPath("$.message").value("Gasto reservado creado correctamente"))
+                .andExpect(jsonPath("$.data.id").value(11L))
+                .andExpect(jsonPath("$.data.tipo").value(TipoFin.EGRESO.name()))
+                .andExpect(jsonPath("$.data.categoriaId").value(5L))
+                .andExpect(jsonPath("$.data.concepto").value("Pago consultoría"))
+                .andExpect(jsonPath("$.data.estado").value(EstadoReserva.RESERVADO.name()))
+                .andExpect(jsonPath("$.data.montoReservado").value(1500.00))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(categoriaFinancieraService).get(5L);
+        verify(gastoReservadoMapper).toEntity(ArgumentMatchers.any(GastoReservadoCreateDto.class), eq(categoria));
+        verify(gastoReservadoService).create(entityToCreate);
+        verify(gastoReservadoMapper).toDto(saved);
+        verifyNoMoreInteractions(gastoReservadoService, categoriaFinancieraService, gastoReservadoMapper);
+    }
+
+    @Test
+    void listShouldReturnPagedResponseWithHeaders() throws Exception {
+        CategoriaFinanciera servicios = new CategoriaFinanciera();
+        servicios.setId(5L);
+        servicios.setNombre("Servicios");
+        servicios.setTipo(TipoFin.EGRESO);
+
+        CategoriaFinanciera salarios = new CategoriaFinanciera();
+        salarios.setId(6L);
+        salarios.setNombre("Salarios");
+        salarios.setTipo(TipoFin.INGRESO);
+
+        GastoReservado egreso = new GastoReservado();
+        egreso.setId(20L);
+        egreso.setCategoria(servicios);
+        egreso.setTipo(TipoFin.EGRESO);
+
+        GastoReservado ingreso = new GastoReservado();
+        ingreso.setId(21L);
+        ingreso.setCategoria(salarios);
+        ingreso.setTipo(TipoFin.INGRESO);
+
+        GastoReservadoResponseDto egresoDto = new GastoReservadoResponseDto(
+                20L,
+                TipoFin.EGRESO,
+                5L,
+                "Servicios",
+                "Pago consultoría",
+                LocalDate.of(2024, 5, 1),
+                LocalDate.of(2024, 5, 10),
+                EstadoReserva.RESERVADO,
+                new BigDecimal("1500.00"),
+                BigDecimal.ZERO,
+                "Mensual",
+                null,
+                null
+        );
+
+        GastoReservadoResponseDto ingresoDto = new GastoReservadoResponseDto(
+                21L,
+                TipoFin.INGRESO,
+                6L,
+                "Salarios",
+                "Ingreso mensual",
+                LocalDate.of(2024, 5, 1),
+                null,
+                EstadoReserva.APLICADO,
+                new BigDecimal("5000.00"),
+                new BigDecimal("5000.00"),
+                null,
+                null,
+                null
+        );
+
+        Page<GastoReservado> page = new PageImpl<>(List.of(egreso, ingreso), PageRequest.of(0, 2), 4);
+
+        when(gastoReservadoService.list(ArgumentMatchers.isNull(), any(Pageable.class))).thenReturn(page);
+        when(gastoReservadoMapper.toDto(egreso)).thenReturn(egresoDto);
+        when(gastoReservadoMapper.toDto(ingreso)).thenReturn(ingresoDto);
+
+        mockMvc.perform(get("/api/gastos-reservados")
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Total-Count", "4"))
+                .andExpect(header().string(HttpHeaders.LINK, containsString("rel=\"next\"")))
+                .andExpect(header().string(HttpHeaders.LINK, containsString("rel=\"last\"")))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].id").value(20L))
+                .andExpect(jsonPath("$.data[0].categoriaNombre").value("Servicios"))
+                .andExpect(jsonPath("$.data[1].id").value(21L))
+                .andExpect(jsonPath("$.data[1].tipo").value(TipoFin.INGRESO.name()))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(gastoReservadoService).list(ArgumentMatchers.isNull(), any(Pageable.class));
+        verify(gastoReservadoMapper).toDto(egreso);
+        verify(gastoReservadoMapper).toDto(ingreso);
+        verifyNoMoreInteractions(gastoReservadoService, gastoReservadoMapper, categoriaFinancieraService);
+    }
+
+    @Test
+    void getShouldReturnExistingGasto() throws Exception {
+        CategoriaFinanciera categoria = new CategoriaFinanciera();
+        categoria.setId(7L);
+        categoria.setNombre("Honorarios");
+        categoria.setTipo(TipoFin.EGRESO);
+
+        GastoReservado gasto = new GastoReservado();
+        gasto.setId(30L);
+        gasto.setCategoria(categoria);
+        gasto.setTipo(TipoFin.EGRESO);
+
+        GastoReservadoResponseDto dto = new GastoReservadoResponseDto(
+                30L,
+                TipoFin.EGRESO,
+                7L,
+                "Honorarios",
+                "Pago asesoría",
+                LocalDate.of(2024, 6, 1),
+                LocalDate.of(2024, 6, 10),
+                EstadoReserva.RESERVADO,
+                new BigDecimal("1200.00"),
+                null,
+                null,
+                null,
+                null
+        );
+
+        when(gastoReservadoService.get(30L)).thenReturn(gasto);
+        when(gastoReservadoMapper.toDto(gasto)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/gastos-reservados/{id}", 30L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(30L))
+                .andExpect(jsonPath("$.data.categoriaNombre").value("Honorarios"))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(gastoReservadoService).get(30L);
+        verify(gastoReservadoMapper).toDto(gasto);
+        verifyNoMoreInteractions(gastoReservadoService, gastoReservadoMapper, categoriaFinancieraService);
+    }
+
+    @Test
+    void updateShouldReturnUpdatedGasto() throws Exception {
+        GastoReservadoPatchDto patchDto = new GastoReservadoPatchDto();
+        patchDto.setCategoriaId(9L);
+        patchDto.setConcepto("Actualizado");
+        patchDto.setMontoReservado(new BigDecimal("1800.00"));
+
+        CategoriaFinanciera categoria = new CategoriaFinanciera();
+        categoria.setId(9L);
+        categoria.setNombre("Servicios");
+        categoria.setTipo(TipoFin.EGRESO);
+
+        GastoReservado cambios = new GastoReservado();
+        cambios.setCategoria(categoria);
+        cambios.setConcepto("Actualizado");
+
+        GastoReservado updated = new GastoReservado();
+        updated.setId(40L);
+        updated.setCategoria(categoria);
+        updated.setTipo(TipoFin.EGRESO);
+        updated.setConcepto("Actualizado");
+        updated.setMontoReservado(new BigDecimal("1800.00"));
+
+        GastoReservadoResponseDto responseDto = new GastoReservadoResponseDto(
+                40L,
+                TipoFin.EGRESO,
+                9L,
+                "Servicios",
+                "Actualizado",
+                LocalDate.of(2024, 7, 1),
+                null,
+                EstadoReserva.RESERVADO,
+                new BigDecimal("1800.00"),
+                null,
+                null,
+                null,
+                null
+        );
+
+        when(categoriaFinancieraService.get(9L)).thenReturn(categoria);
+        when(gastoReservadoMapper.toPartialEntity(ArgumentMatchers.any(GastoReservadoPatchDto.class), eq(categoria)))
+                .thenReturn(cambios);
+        when(gastoReservadoService.update(40L, cambios)).thenReturn(updated);
+        when(gastoReservadoMapper.toDto(updated)).thenReturn(responseDto);
+
+        mockMvc.perform(patch("/api/gastos-reservados/{id}", 40L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(patchDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(40L))
+                .andExpect(jsonPath("$.data.categoriaId").value(9L))
+                .andExpect(jsonPath("$.data.montoReservado").value(1800.00))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(categoriaFinancieraService).get(9L);
+        verify(gastoReservadoMapper).toPartialEntity(ArgumentMatchers.any(GastoReservadoPatchDto.class), eq(categoria));
+        verify(gastoReservadoService).update(40L, cambios);
+        verify(gastoReservadoMapper).toDto(updated);
+        verifyNoMoreInteractions(gastoReservadoService, categoriaFinancieraService, gastoReservadoMapper);
+    }
+
+    @Test
+    void deleteShouldReturnNoContent() throws Exception {
+        doNothing().when(gastoReservadoService).delete(55L);
+
+        mockMvc.perform(delete("/api/gastos-reservados/{id}", 55L))
+                .andExpect(status().isNoContent());
+
+        verify(gastoReservadoService).delete(55L);
+        verifyNoMoreInteractions(gastoReservadoService);
+        verifyNoMoreInteractions(categoriaFinancieraService, gastoReservadoMapper);
+    }
+}

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/CategoriaFinancieraServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/CategoriaFinancieraServiceImplTest.java
@@ -1,0 +1,211 @@
+package com.ahumadamob.fnanz.service.jpa;
+
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import com.ahumadamob.fnanz.enums.TipoFin;
+import com.ahumadamob.fnanz.error.ResourceConflictException;
+import com.ahumadamob.fnanz.error.ResourceNotFoundException;
+import com.ahumadamob.fnanz.repository.CategoriaFinancieraRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CategoriaFinancieraServiceImplTest {
+
+    @Mock
+    private CategoriaFinancieraRepository categoriaFinancieraRepository;
+
+    @InjectMocks
+    private CategoriaFinancieraServiceImpl service;
+
+    @Test
+    void createShouldPersistWhenNombreIsUnique() {
+        CategoriaFinanciera toCreate = buildCategoria(null, "Salario", TipoFin.INGRESO);
+        CategoriaFinanciera saved = buildCategoria(1L, "Salario", TipoFin.INGRESO);
+
+        when(categoriaFinancieraRepository.findByNombre("Salario")).thenReturn(Optional.empty());
+        when(categoriaFinancieraRepository.save(toCreate)).thenReturn(saved);
+
+        CategoriaFinanciera result = service.create(toCreate);
+
+        assertThat(result).isSameAs(saved);
+    }
+
+    @Test
+    void createShouldThrowConflictWhenNombreAlreadyExists() {
+        CategoriaFinanciera toCreate = buildCategoria(null, "Salario", TipoFin.INGRESO);
+        CategoriaFinanciera existing = buildCategoria(99L, "Salario", TipoFin.INGRESO);
+
+        when(categoriaFinancieraRepository.findByNombre("Salario")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.create(toCreate))
+                .isInstanceOf(ResourceConflictException.class);
+        verify(categoriaFinancieraRepository, never()).save(any());
+    }
+
+    @Test
+    void getShouldReturnCategoriaWhenExists() {
+        CategoriaFinanciera categoria = buildCategoria(4L, "Servicios", TipoFin.EGRESO);
+        when(categoriaFinancieraRepository.findById(4L)).thenReturn(Optional.of(categoria));
+
+        CategoriaFinanciera result = service.get(4L);
+
+        assertThat(result).isSameAs(categoria);
+    }
+
+    @Test
+    void getShouldThrowWhenCategoriaDoesNotExist() {
+        when(categoriaFinancieraRepository.findById(4L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.get(4L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void updateShouldApplyProvidedChanges() {
+        CategoriaFinanciera existing = buildCategoria(5L, "Salario", TipoFin.INGRESO);
+        existing.setDescripcion("Ingresos principales");
+        existing.setOrden(1);
+
+        CategoriaFinanciera cambios = new CategoriaFinanciera();
+        cambios.setNombre("Renta");
+        cambios.setTipo(TipoFin.EGRESO);
+        cambios.setActivo(false);
+        cambios.setOrden(3);
+        cambios.setDescripcion("Pagos mensuales");
+
+        when(categoriaFinancieraRepository.findById(5L)).thenReturn(Optional.of(existing));
+        when(categoriaFinancieraRepository.findByNombre("Renta")).thenReturn(Optional.empty());
+        when(categoriaFinancieraRepository.save(existing)).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CategoriaFinanciera result = service.update(5L, cambios);
+
+        assertThat(result.getNombre()).isEqualTo("Renta");
+        assertThat(result.getTipo()).isEqualTo(TipoFin.EGRESO);
+        assertThat(result.getActivo()).isFalse();
+        assertThat(result.getOrden()).isEqualTo(3);
+        assertThat(result.getDescripcion()).isEqualTo("Pagos mensuales");
+    }
+
+    @Test
+    void updateShouldThrowConflictWhenNombreBelongsToAnotherCategoria() {
+        CategoriaFinanciera existing = buildCategoria(5L, "Salario", TipoFin.INGRESO);
+        CategoriaFinanciera cambios = new CategoriaFinanciera();
+        cambios.setNombre("Renta");
+
+        CategoriaFinanciera another = buildCategoria(8L, "Renta", TipoFin.EGRESO);
+
+        when(categoriaFinancieraRepository.findById(5L)).thenReturn(Optional.of(existing));
+        when(categoriaFinancieraRepository.findByNombre("Renta")).thenReturn(Optional.of(another));
+
+        assertThatThrownBy(() -> service.update(5L, cambios))
+                .isInstanceOf(ResourceConflictException.class);
+        verify(categoriaFinancieraRepository, never()).save(any());
+    }
+
+    @Test
+    void updateShouldNotQueryNombreWhenUnchanged() {
+        CategoriaFinanciera existing = buildCategoria(5L, "Salario", TipoFin.INGRESO);
+        existing.setDescripcion("Ingresos principales");
+
+        CategoriaFinanciera cambios = new CategoriaFinanciera();
+        cambios.setNombre("Salario");
+        cambios.setDescripcion("Actualizado");
+
+        when(categoriaFinancieraRepository.findById(5L)).thenReturn(Optional.of(existing));
+        when(categoriaFinancieraRepository.save(existing)).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CategoriaFinanciera result = service.update(5L, cambios);
+
+        assertThat(result.getDescripcion()).isEqualTo("Actualizado");
+        verify(categoriaFinancieraRepository, never()).findByNombre(anyString());
+    }
+
+    @Test
+    void updateShouldThrowWhenCategoriaDoesNotExist() {
+        CategoriaFinanciera cambios = new CategoriaFinanciera();
+        cambios.setNombre("Renta");
+
+        when(categoriaFinancieraRepository.findById(5L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.update(5L, cambios))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void deleteShouldRemoveCategoriaWhenExists() {
+        when(categoriaFinancieraRepository.existsById(10L)).thenReturn(true);
+
+        service.delete(10L);
+
+        verify(categoriaFinancieraRepository).deleteById(10L);
+    }
+
+    @Test
+    void deleteShouldThrowWhenCategoriaDoesNotExist() {
+        when(categoriaFinancieraRepository.existsById(10L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.delete(10L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void listShouldUseNullSpecificationWhenQueryIsBlank() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<CategoriaFinanciera> expected = new PageImpl<>(List.of());
+        when(categoriaFinancieraRepository.findAll((Specification<CategoriaFinanciera>) any(), eq(pageable)))
+                .thenReturn(expected);
+
+        Page<CategoriaFinanciera> result = service.list("   ", pageable);
+
+        assertThat(result).isSameAs(expected);
+        verify(categoriaFinancieraRepository).findAll(isNull(), eq(pageable));
+        verifyNoMoreInteractions(categoriaFinancieraRepository);
+    }
+
+    @Test
+    void listShouldBuildSpecificationWhenQueryIsPresent() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<CategoriaFinanciera> expected = new PageImpl<>(List.of());
+        when(categoriaFinancieraRepository.findAll((Specification<CategoriaFinanciera>) any(), eq(pageable)))
+                .thenReturn(expected);
+
+        Page<CategoriaFinanciera> result = service.list("ing", pageable);
+
+        assertThat(result).isSameAs(expected);
+        ArgumentCaptor<Specification<CategoriaFinanciera>> captor = ArgumentCaptor.forClass(Specification.class);
+        verify(categoriaFinancieraRepository).findAll(captor.capture(), eq(pageable));
+        assertThat(captor.getValue()).isNotNull();
+    }
+
+    private CategoriaFinanciera buildCategoria(Long id, String nombre, TipoFin tipo) {
+        CategoriaFinanciera categoria = new CategoriaFinanciera();
+        categoria.setId(id);
+        categoria.setNombre(nombre);
+        categoria.setTipo(tipo);
+        categoria.setActivo(true);
+        return categoria;
+    }
+}

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/CategoriaFinancieraServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/CategoriaFinancieraServiceImplTest.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -172,16 +171,15 @@ class CategoriaFinancieraServiceImplTest {
     }
 
     @Test
-    void listShouldUseNullSpecificationWhenQueryIsBlank() {
+    void listShouldCallSimpleFindAllWhenQueryIsBlank() {
         Pageable pageable = PageRequest.of(0, 10);
         Page<CategoriaFinanciera> expected = new PageImpl<>(List.of());
-        when(categoriaFinancieraRepository.findAll(any(Specification.class), eq(pageable)))
-                .thenReturn(expected);
+        when(categoriaFinancieraRepository.findAll(pageable)).thenReturn(expected);
 
         Page<CategoriaFinanciera> result = service.list("   ", pageable);
 
         assertThat(result).isSameAs(expected);
-        verify(categoriaFinancieraRepository).findAll(isNull(Specification.class), eq(pageable));
+        verify(categoriaFinancieraRepository).findAll(pageable);
         verifyNoMoreInteractions(categoriaFinancieraRepository);
     }
 

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/CategoriaFinancieraServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/CategoriaFinancieraServiceImplTest.java
@@ -175,13 +175,13 @@ class CategoriaFinancieraServiceImplTest {
     void listShouldUseNullSpecificationWhenQueryIsBlank() {
         Pageable pageable = PageRequest.of(0, 10);
         Page<CategoriaFinanciera> expected = new PageImpl<>(List.of());
-        when(categoriaFinancieraRepository.findAll((Specification<CategoriaFinanciera>) any(), eq(pageable)))
+        when(categoriaFinancieraRepository.findAll(any(Specification.class), eq(pageable)))
                 .thenReturn(expected);
 
         Page<CategoriaFinanciera> result = service.list("   ", pageable);
 
         assertThat(result).isSameAs(expected);
-        verify(categoriaFinancieraRepository).findAll(isNull(), eq(pageable));
+        verify(categoriaFinancieraRepository).findAll(isNull(Specification.class), eq(pageable));
         verifyNoMoreInteractions(categoriaFinancieraRepository);
     }
 
@@ -189,7 +189,7 @@ class CategoriaFinancieraServiceImplTest {
     void listShouldBuildSpecificationWhenQueryIsPresent() {
         Pageable pageable = PageRequest.of(0, 10);
         Page<CategoriaFinanciera> expected = new PageImpl<>(List.of());
-        when(categoriaFinancieraRepository.findAll((Specification<CategoriaFinanciera>) any(), eq(pageable)))
+        when(categoriaFinancieraRepository.findAll(any(Specification.class), eq(pageable)))
                 .thenReturn(expected);
 
         Page<CategoriaFinanciera> result = service.list("ing", pageable);

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImplTest.java
@@ -1,0 +1,212 @@
+package com.ahumadamob.fnanz.service.jpa;
+
+import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
+import com.ahumadamob.fnanz.entity.GastoReservado;
+import com.ahumadamob.fnanz.enums.EstadoReserva;
+import com.ahumadamob.fnanz.enums.TipoFin;
+import com.ahumadamob.fnanz.error.ResourceConflictException;
+import com.ahumadamob.fnanz.error.ResourceNotFoundException;
+import com.ahumadamob.fnanz.repository.GastoReservadoRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GastoReservadoServiceImplTest {
+
+    @Mock
+    private GastoReservadoRepository gastoReservadoRepository;
+
+    @InjectMocks
+    private GastoReservadoServiceImpl service;
+
+    @Test
+    void createShouldPersistWhenTipoMatchesCategoria() {
+        CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
+        GastoReservado toCreate = buildGasto(null, TipoFin.EGRESO, categoria);
+        toCreate.setEstado(EstadoReserva.RESERVADO);
+
+        GastoReservado saved = buildGasto(10L, TipoFin.EGRESO, categoria);
+        saved.setEstado(EstadoReserva.RESERVADO);
+
+        when(gastoReservadoRepository.save(toCreate)).thenReturn(saved);
+
+        GastoReservado result = service.create(toCreate);
+
+        assertThat(result).isSameAs(saved);
+    }
+
+    @Test
+    void createShouldThrowConflictWhenTipoDiffersFromCategoria() {
+        CategoriaFinanciera categoria = buildCategoria(1L, "Salario", TipoFin.INGRESO);
+        GastoReservado toCreate = buildGasto(null, TipoFin.EGRESO, categoria);
+
+        assertThatThrownBy(() -> service.create(toCreate))
+                .isInstanceOf(ResourceConflictException.class);
+        verify(gastoReservadoRepository, never()).save(any());
+    }
+
+    @Test
+    void getShouldReturnGastoWhenExists() {
+        CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
+        GastoReservado gasto = buildGasto(5L, TipoFin.EGRESO, categoria);
+        when(gastoReservadoRepository.findById(5L)).thenReturn(Optional.of(gasto));
+
+        GastoReservado result = service.get(5L);
+
+        assertThat(result).isSameAs(gasto);
+    }
+
+    @Test
+    void getShouldThrowWhenGastoDoesNotExist() {
+        when(gastoReservadoRepository.findById(5L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.get(5L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void updateShouldApplyProvidedChanges() {
+        CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
+        CategoriaFinanciera nuevaCategoria = buildCategoria(2L, "Honorarios", TipoFin.EGRESO);
+        GastoReservado existing = buildGasto(8L, TipoFin.EGRESO, categoria);
+        existing.setConcepto("Pago consultoría");
+        existing.setNota("Mensual");
+
+        GastoReservado cambios = new GastoReservado();
+        cambios.setTipo(TipoFin.EGRESO);
+        cambios.setCategoria(nuevaCategoria);
+        cambios.setConcepto("Pago asesoría");
+        cambios.setPeriodoFecha(LocalDate.of(2024, 6, 1));
+        cambios.setFechaVencimiento(LocalDate.of(2024, 6, 10));
+        cambios.setEstado(EstadoReserva.APLICADO);
+        cambios.setMontoReservado(new BigDecimal("2000.00"));
+        cambios.setMontoAplicado(new BigDecimal("1800.00"));
+        cambios.setNota("Actualizado");
+
+        when(gastoReservadoRepository.findById(8L)).thenReturn(Optional.of(existing));
+        when(gastoReservadoRepository.save(existing)).thenAnswer(invocation -> invocation.getArgument(0));
+
+        GastoReservado result = service.update(8L, cambios);
+
+        assertThat(result.getCategoria()).isSameAs(nuevaCategoria);
+        assertThat(result.getConcepto()).isEqualTo("Pago asesoría");
+        assertThat(result.getPeriodoFecha()).isEqualTo(LocalDate.of(2024, 6, 1));
+        assertThat(result.getFechaVencimiento()).isEqualTo(LocalDate.of(2024, 6, 10));
+        assertThat(result.getEstado()).isEqualTo(EstadoReserva.APLICADO);
+        assertThat(result.getMontoReservado()).isEqualByComparingTo("2000.00");
+        assertThat(result.getMontoAplicado()).isEqualByComparingTo("1800.00");
+        assertThat(result.getNota()).isEqualTo("Actualizado");
+    }
+
+    @Test
+    void updateShouldThrowConflictWhenTipoDoesNotMatchCategoria() {
+        CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
+        GastoReservado existing = buildGasto(8L, TipoFin.EGRESO, categoria);
+
+        GastoReservado cambios = new GastoReservado();
+        cambios.setTipo(TipoFin.INGRESO);
+
+        when(gastoReservadoRepository.findById(8L)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.update(8L, cambios))
+                .isInstanceOf(ResourceConflictException.class);
+        verify(gastoReservadoRepository, never()).save(any());
+    }
+
+    @Test
+    void updateShouldThrowWhenGastoDoesNotExist() {
+        GastoReservado cambios = new GastoReservado();
+        cambios.setTipo(TipoFin.EGRESO);
+
+        when(gastoReservadoRepository.findById(8L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.update(8L, cambios))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void deleteShouldRemoveGastoWhenExists() {
+        when(gastoReservadoRepository.existsById(3L)).thenReturn(true);
+
+        service.delete(3L);
+
+        verify(gastoReservadoRepository).deleteById(3L);
+    }
+
+    @Test
+    void deleteShouldThrowWhenGastoDoesNotExist() {
+        when(gastoReservadoRepository.existsById(3L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.delete(3L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void listShouldCallSimpleFindAllWhenQueryIsBlank() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<GastoReservado> expected = new PageImpl<>(List.of());
+        when(gastoReservadoRepository.findAll(pageable)).thenReturn(expected);
+
+        Page<GastoReservado> result = service.list("   ", pageable);
+
+        assertThat(result).isSameAs(expected);
+        verify(gastoReservadoRepository).findAll(pageable);
+        verifyNoMoreInteractions(gastoReservadoRepository);
+    }
+
+    @Test
+    void listShouldBuildSpecificationWhenQueryIsPresent() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<GastoReservado> expected = new PageImpl<>(List.of());
+        when(gastoReservadoRepository.findAll(any(Specification.class), eq(pageable)))
+                .thenReturn(expected);
+
+        Page<GastoReservado> result = service.list("consult", pageable);
+
+        assertThat(result).isSameAs(expected);
+        ArgumentCaptor<Specification<GastoReservado>> captor = ArgumentCaptor.forClass(Specification.class);
+        verify(gastoReservadoRepository).findAll(captor.capture(), eq(pageable));
+        assertThat(captor.getValue()).isNotNull();
+    }
+
+    private CategoriaFinanciera buildCategoria(Long id, String nombre, TipoFin tipo) {
+        CategoriaFinanciera categoria = new CategoriaFinanciera();
+        categoria.setId(id);
+        categoria.setNombre(nombre);
+        categoria.setTipo(tipo);
+        categoria.setActivo(true);
+        return categoria;
+    }
+
+    private GastoReservado buildGasto(Long id, TipoFin tipo, CategoriaFinanciera categoria) {
+        GastoReservado gasto = new GastoReservado();
+        gasto.setId(id);
+        gasto.setTipo(tipo);
+        gasto.setCategoria(categoria);
+        gasto.setPeriodoFecha(LocalDate.of(2024, 5, 1));
+        gasto.setMontoReservado(new BigDecimal("1000.00"));
+        return gasto;
+    }
+}


### PR DESCRIPTION
## Summary
- add the CategoriaFinanciera entity along with its TipoFin enum
- implement DTOs, mapper, repository, service and REST controller for financial categories

## Testing
- `mvn -q test` *(fails: cannot download parent POM because the Maven Central repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d07b678618832faf9926347525707e