### PR TITLE
Enable CORS support for Angular frontend

### DIFF
--- a/src/main/java/com/ahumadamob/fnanz/config/CorsConfig.java
+++ b/src/main/java/com/ahumadamob/fnanz/config/CorsConfig.java
@@ -1,0 +1,32 @@
+package com.ahumadamob.fnanz.config;
+
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    private final String[] allowedOrigins;
+
+    public CorsConfig(@Value("${app.cors.allowed-origins:http://localhost:4200}") String allowedOrigins) {
+        String[] origins = Arrays.stream(allowedOrigins.split(","))
+            .map(String::trim)
+            .filter(StringUtils::hasText)
+            .toArray(String[]::new);
+        this.allowedOrigins = origins.length == 0 ? new String[] {"http://localhost:4200"} : origins;
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOriginPatterns(allowedOrigins)
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+app.cors.allowed-origins=http://localhost:4200


### PR DESCRIPTION
## Summary
- add a WebMvcConfigurer-based CORS configuration so Angular clients can reach the API
- provide a configurable list of allowed origins with a default for the Angular dev server

## Testing
- `mvn -q test` *(fails: Maven cannot download the Spring Boot parent POM because the network is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d099cabc1c832fb462ed186e40ec23