### PR TITLE
Introduce reusable financial periods for reserved expenses

### DIFF
--- a/src/main/java/com/ahumadamob/fnanz/controller/GastoReservadoController.java
+++ b/src/main/java/com/ahumadamob/fnanz/controller/GastoReservadoController.java
@@ -6,9 +6,11 @@ import com.ahumadamob.fnanz.dto.response.ApiResponseSuccessDto;
 import com.ahumadamob.fnanz.dto.response.GastoReservadoResponseDto;
 import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
 import com.ahumadamob.fnanz.entity.GastoReservado;
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.mapper.GastoReservadoMapper;
 import com.ahumadamob.fnanz.service.CategoriaFinancieraService;
 import com.ahumadamob.fnanz.service.GastoReservadoService;
+import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,19 +40,23 @@ public class GastoReservadoController {
     private final GastoReservadoService gastoReservadoService;
     private final CategoriaFinancieraService categoriaFinancieraService;
     private final GastoReservadoMapper gastoReservadoMapper;
+    private final PeriodoFinancieroService periodoFinancieroService;
 
     public GastoReservadoController(GastoReservadoService gastoReservadoService,
                                     CategoriaFinancieraService categoriaFinancieraService,
-                                    GastoReservadoMapper gastoReservadoMapper) {
+                                    GastoReservadoMapper gastoReservadoMapper,
+                                    PeriodoFinancieroService periodoFinancieroService) {
         this.gastoReservadoService = gastoReservadoService;
         this.categoriaFinancieraService = categoriaFinancieraService;
         this.gastoReservadoMapper = gastoReservadoMapper;
+        this.periodoFinancieroService = periodoFinancieroService;
     }
 
     @PostMapping
     public ResponseEntity<ApiResponseSuccessDto<GastoReservadoResponseDto>> create(@Validated @RequestBody GastoReservadoCreateDto dto) {
         CategoriaFinanciera categoria = categoriaFinancieraService.get(dto.getCategoriaId());
-        GastoReservado gasto = gastoReservadoMapper.toEntity(dto, categoria);
+        PeriodoFinanciero periodo = periodoFinancieroService.get(dto.getPeriodoId());
+        GastoReservado gasto = gastoReservadoMapper.toEntity(dto, categoria, periodo);
         GastoReservado created = gastoReservadoService.create(gasto);
         GastoReservadoResponseDto response = gastoReservadoMapper.toDto(created);
         return created(response.getId(), "Gasto reservado creado correctamente", response);
@@ -77,7 +83,10 @@ public class GastoReservadoController {
         if (dto.getCategoriaId() != null) {
             categoria = categoriaFinancieraService.get(dto.getCategoriaId());
         }
-        GastoReservado cambios = gastoReservadoMapper.toPartialEntity(dto, categoria);
+        PeriodoFinanciero periodo = dto.getPeriodoId() != null
+                ? periodoFinancieroService.get(dto.getPeriodoId())
+                : null;
+        GastoReservado cambios = gastoReservadoMapper.toPartialEntity(dto, categoria, periodo);
         GastoReservado updated = gastoReservadoService.update(id, cambios);
         return ok(gastoReservadoMapper.toDto(updated));
     }

--- a/src/main/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroController.java
+++ b/src/main/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroController.java
@@ -1,0 +1,36 @@
+package com.ahumadamob.fnanz.controller;
+
+import com.ahumadamob.fnanz.dto.response.ApiResponseSuccessDto;
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import com.ahumadamob.fnanz.mapper.PeriodoFinancieroMapper;
+import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.ahumadamob.fnanz.controller.ResponseFactory.ok;
+
+/**
+ * Controlador REST para periodos financieros reutilizables.
+ */
+@RestController
+@RequestMapping("/api/periodos-financieros")
+public class PeriodoFinancieroController {
+
+    private final PeriodoFinancieroService periodoFinancieroService;
+    private final PeriodoFinancieroMapper periodoFinancieroMapper;
+
+    public PeriodoFinancieroController(PeriodoFinancieroService periodoFinancieroService,
+                                       PeriodoFinancieroMapper periodoFinancieroMapper) {
+        this.periodoFinancieroService = periodoFinancieroService;
+        this.periodoFinancieroMapper = periodoFinancieroMapper;
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponseSuccessDto<PeriodoFinancieroResponseDto> get(@PathVariable Long id) {
+        PeriodoFinanciero periodo = periodoFinancieroService.get(id);
+        return ok(periodoFinancieroMapper.toDto(periodo));
+    }
+}

--- a/src/main/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroController.java
+++ b/src/main/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroController.java
@@ -1,5 +1,7 @@
 package com.ahumadamob.fnanz.controller;
 
+import com.ahumadamob.fnanz.dto.PeriodoFinancieroCreateDto;
+import com.ahumadamob.fnanz.dto.PeriodoFinancieroPatchDto;
 import com.ahumadamob.fnanz.dto.response.ApiResponseSuccessDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
@@ -8,12 +10,21 @@ import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.ahumadamob.fnanz.controller.ResponseFactory.created;
 import static com.ahumadamob.fnanz.controller.ResponseFactory.ok;
 import static com.ahumadamob.fnanz.controller.ResponseFactory.page;
 
@@ -33,6 +44,15 @@ public class PeriodoFinancieroController {
         this.periodoFinancieroMapper = periodoFinancieroMapper;
     }
 
+    @PostMapping
+    public ResponseEntity<ApiResponseSuccessDto<PeriodoFinancieroResponseDto>> create(
+            @Validated @RequestBody PeriodoFinancieroCreateDto dto) {
+        PeriodoFinanciero periodo = periodoFinancieroMapper.toEntity(dto);
+        PeriodoFinanciero createdPeriodo = periodoFinancieroService.create(periodo);
+        PeriodoFinancieroResponseDto response = periodoFinancieroMapper.toDto(createdPeriodo);
+        return created(response.getId(), "Periodo financiero creado correctamente", response);
+    }
+
     @GetMapping
     public ResponseEntity<ApiResponseSuccessDto<List<PeriodoFinancieroResponseDto>>> list(Pageable pageable) {
         Page<PeriodoFinanciero> pageResult = periodoFinancieroService.list(pageable);
@@ -44,5 +64,27 @@ public class PeriodoFinancieroController {
     public ApiResponseSuccessDto<PeriodoFinancieroResponseDto> get(@PathVariable Long id) {
         PeriodoFinanciero periodo = periodoFinancieroService.get(id);
         return ok(periodoFinancieroMapper.toDto(periodo));
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponseSuccessDto<PeriodoFinancieroResponseDto> replace(@PathVariable Long id,
+            @Validated @RequestBody PeriodoFinancieroCreateDto dto) {
+        PeriodoFinanciero cambios = periodoFinancieroMapper.toEntity(dto);
+        PeriodoFinanciero actualizado = periodoFinancieroService.replace(id, cambios);
+        return ok(periodoFinancieroMapper.toDto(actualizado));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponseSuccessDto<PeriodoFinancieroResponseDto> update(@PathVariable Long id,
+            @Validated @RequestBody PeriodoFinancieroPatchDto dto) {
+        PeriodoFinanciero cambios = periodoFinancieroMapper.toPartialEntity(dto);
+        PeriodoFinanciero actualizado = periodoFinancieroService.update(id, cambios);
+        return ok(periodoFinancieroMapper.toDto(actualizado));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        periodoFinancieroService.delete(id);
     }
 }

--- a/src/main/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroController.java
+++ b/src/main/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroController.java
@@ -5,12 +5,17 @@ import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.mapper.PeriodoFinancieroMapper;
 import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.ahumadamob.fnanz.controller.ResponseFactory.ok;
+import static com.ahumadamob.fnanz.controller.ResponseFactory.page;
 
 /**
  * Controlador REST para periodos financieros reutilizables.
@@ -26,6 +31,13 @@ public class PeriodoFinancieroController {
                                        PeriodoFinancieroMapper periodoFinancieroMapper) {
         this.periodoFinancieroService = periodoFinancieroService;
         this.periodoFinancieroMapper = periodoFinancieroMapper;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponseSuccessDto<List<PeriodoFinancieroResponseDto>>> list(Pageable pageable) {
+        Page<PeriodoFinanciero> pageResult = periodoFinancieroService.list(pageable);
+        Page<PeriodoFinancieroResponseDto> dtoPage = pageResult.map(periodoFinancieroMapper::toDto);
+        return page(dtoPage);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/ahumadamob/fnanz/dto/GastoReservadoCreateDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/GastoReservadoCreateDto.java
@@ -3,7 +3,6 @@ package com.ahumadamob.fnanz.dto;
 import com.ahumadamob.fnanz.enums.EstadoReserva;
 import com.ahumadamob.fnanz.enums.TipoFin;
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,9 +21,7 @@ public class GastoReservadoCreateDto {
 
     private String concepto;
 
-    private LocalDate periodoFecha;
-
-    private LocalDate fechaVencimiento;
+    private Long periodoId;
 
     private EstadoReserva estado;
 

--- a/src/main/java/com/ahumadamob/fnanz/dto/GastoReservadoPatchDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/GastoReservadoPatchDto.java
@@ -3,7 +3,6 @@ package com.ahumadamob.fnanz.dto;
 import com.ahumadamob.fnanz.enums.EstadoReserva;
 import com.ahumadamob.fnanz.enums.TipoFin;
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,9 +21,7 @@ public class GastoReservadoPatchDto {
 
     private String concepto;
 
-    private LocalDate periodoFecha;
-
-    private LocalDate fechaVencimiento;
+    private Long periodoId;
 
     private EstadoReserva estado;
 

--- a/src/main/java/com/ahumadamob/fnanz/dto/PeriodoFinancieroCreateDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/PeriodoFinancieroCreateDto.java
@@ -1,0 +1,27 @@
+package com.ahumadamob.fnanz.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO para la creación o reemplazo completo de periodos financieros.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class PeriodoFinancieroCreateDto {
+
+    private String nombre;
+
+    private LocalDate fechaInicio;
+
+    private LocalDate fechaFin;
+
+    private String tipo;
+
+    private String descripcion;
+
+    private Boolean cerrado;
+}

--- a/src/main/java/com/ahumadamob/fnanz/dto/PeriodoFinancieroPatchDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/PeriodoFinancieroPatchDto.java
@@ -1,0 +1,27 @@
+package com.ahumadamob.fnanz.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO para actualizaciones parciales de periodos financieros.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class PeriodoFinancieroPatchDto {
+
+    private String nombre;
+
+    private LocalDate fechaInicio;
+
+    private LocalDate fechaFin;
+
+    private String tipo;
+
+    private String descripcion;
+
+    private Boolean cerrado;
+}

--- a/src/main/java/com/ahumadamob/fnanz/dto/response/GastoReservadoResponseDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/GastoReservadoResponseDto.java
@@ -29,9 +29,13 @@ public class GastoReservadoResponseDto {
 
     private String concepto;
 
-    private LocalDate periodoFecha;
+    private Long periodoId;
 
-    private LocalDate fechaVencimiento;
+    private String periodoNombre;
+
+    private LocalDate periodoFechaInicio;
+
+    private LocalDate periodoFechaFin;
 
     private EstadoReserva estado;
 

--- a/src/main/java/com/ahumadamob/fnanz/dto/response/PeriodoFinancieroResponseDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/PeriodoFinancieroResponseDto.java
@@ -1,0 +1,36 @@
+package com.ahumadamob.fnanz.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO de lectura para {@code PeriodoFinanciero}.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PeriodoFinancieroResponseDto {
+
+    private Long id;
+
+    private String nombre;
+
+    private LocalDate fechaInicio;
+
+    private LocalDate fechaFin;
+
+    private String tipo;
+
+    private String descripcion;
+
+    private Boolean cerrado;
+
+    private LocalDateTime creadoEn;
+
+    private LocalDateTime actualizadoEn;
+}

--- a/src/main/java/com/ahumadamob/fnanz/entity/GastoReservado.java
+++ b/src/main/java/com/ahumadamob/fnanz/entity/GastoReservado.java
@@ -16,7 +16,6 @@ import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -46,13 +45,11 @@ public class GastoReservado extends BaseEntity {
     @Column(name = "concepto", length = 120)
     private String concepto;
 
-    /** Usar el 1er día del mes como convención de periodo */
     @NotNull
-    @Column(name = "periodo_fecha", nullable = false)
-    private LocalDate periodoFecha;
-
-    @Column(name = "fecha_vencimiento")
-    private LocalDate fechaVencimiento;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "periodo_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_reserva_periodo"))
+    private PeriodoFinanciero periodo;
 
     @NotNull
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/ahumadamob/fnanz/entity/PeriodoFinanciero.java
+++ b/src/main/java/com/ahumadamob/fnanz/entity/PeriodoFinanciero.java
@@ -1,0 +1,57 @@
+package com.ahumadamob.fnanz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Representa un periodo de planificación financiera reutilizable.
+ */
+@Entity
+@Table(name = "periodo_financiero", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_periodo_financiero_nombre", columnNames = "nombre")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+public class PeriodoFinanciero extends BaseEntity {
+
+    @Size(max = 80)
+    @Column(name = "nombre", length = 80, unique = true)
+    private String nombre;
+
+    @NotNull
+    @Column(name = "fecha_inicio", nullable = false)
+    private LocalDate fechaInicio;
+
+    @NotNull
+    @Column(name = "fecha_fin", nullable = false)
+    private LocalDate fechaFin;
+
+    @Size(max = 40)
+    @Column(name = "tipo", length = 40)
+    private String tipo;
+
+    @Column(name = "descripcion", columnDefinition = "text")
+    private String descripcion;
+
+    @NotNull
+    @Column(name = "cerrado", nullable = false)
+    private Boolean cerrado = Boolean.FALSE;
+
+    @AssertTrue(message = "La fecha de inicio debe ser anterior o igual a la fecha de fin")
+    public boolean isRangoValido() {
+        if (fechaInicio == null || fechaFin == null) {
+            return true;
+        }
+        return !fechaFin.isBefore(fechaInicio);
+    }
+}

--- a/src/main/java/com/ahumadamob/fnanz/mapper/GastoReservadoMapper.java
+++ b/src/main/java/com/ahumadamob/fnanz/mapper/GastoReservadoMapper.java
@@ -5,6 +5,7 @@ import com.ahumadamob.fnanz.dto.GastoReservadoPatchDto;
 import com.ahumadamob.fnanz.dto.response.GastoReservadoResponseDto;
 import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
 import com.ahumadamob.fnanz.entity.GastoReservado;
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.enums.EstadoReserva;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
@@ -15,13 +16,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class GastoReservadoMapper {
 
-    public GastoReservado toEntity(GastoReservadoCreateDto dto, CategoriaFinanciera categoria) {
+    public GastoReservado toEntity(GastoReservadoCreateDto dto, CategoriaFinanciera categoria,
+            PeriodoFinanciero periodo) {
         GastoReservado gasto = new GastoReservado();
         gasto.setTipo(dto.getTipo());
         gasto.setCategoria(categoria);
         gasto.setConcepto(dto.getConcepto());
-        gasto.setPeriodoFecha(dto.getPeriodoFecha());
-        gasto.setFechaVencimiento(dto.getFechaVencimiento());
+        gasto.setPeriodo(periodo);
         gasto.setEstado(Optional.ofNullable(dto.getEstado()).orElse(EstadoReserva.RESERVADO));
         gasto.setMontoReservado(dto.getMontoReservado());
         gasto.setMontoAplicado(dto.getMontoAplicado());
@@ -29,20 +30,23 @@ public class GastoReservadoMapper {
         return gasto;
     }
 
-    public GastoReservado toPartialEntity(GastoReservadoPatchDto dto, CategoriaFinanciera categoria) {
+    public GastoReservado toPartialEntity(GastoReservadoPatchDto dto, CategoriaFinanciera categoria,
+            PeriodoFinanciero periodo) {
         GastoReservado gasto = new GastoReservado();
-        updateEntity(dto, gasto, categoria);
+        updateEntity(dto, gasto, categoria, periodo);
         return gasto;
     }
 
-    public void updateEntity(GastoReservadoPatchDto dto, GastoReservado gasto, CategoriaFinanciera categoria) {
+    public void updateEntity(GastoReservadoPatchDto dto, GastoReservado gasto, CategoriaFinanciera categoria,
+            PeriodoFinanciero periodo) {
         Optional.ofNullable(dto.getTipo()).ifPresent(gasto::setTipo);
         if (categoria != null) {
             gasto.setCategoria(categoria);
         }
+        if (periodo != null) {
+            gasto.setPeriodo(periodo);
+        }
         Optional.ofNullable(dto.getConcepto()).ifPresent(gasto::setConcepto);
-        Optional.ofNullable(dto.getPeriodoFecha()).ifPresent(gasto::setPeriodoFecha);
-        Optional.ofNullable(dto.getFechaVencimiento()).ifPresent(gasto::setFechaVencimiento);
         Optional.ofNullable(dto.getEstado()).ifPresent(gasto::setEstado);
         Optional.ofNullable(dto.getMontoReservado()).ifPresent(gasto::setMontoReservado);
         Optional.ofNullable(dto.getMontoAplicado()).ifPresent(gasto::setMontoAplicado);
@@ -51,14 +55,17 @@ public class GastoReservadoMapper {
 
     public GastoReservadoResponseDto toDto(GastoReservado gasto) {
         CategoriaFinanciera categoria = gasto.getCategoria();
+        PeriodoFinanciero periodo = gasto.getPeriodo();
         return new GastoReservadoResponseDto(
                 gasto.getId(),
                 gasto.getTipo(),
                 categoria != null ? categoria.getId() : null,
                 categoria != null ? categoria.getNombre() : null,
                 gasto.getConcepto(),
-                gasto.getPeriodoFecha(),
-                gasto.getFechaVencimiento(),
+                periodo != null ? periodo.getId() : null,
+                periodo != null ? periodo.getNombre() : null,
+                periodo != null ? periodo.getFechaInicio() : null,
+                periodo != null ? periodo.getFechaFin() : null,
                 gasto.getEstado(),
                 gasto.getMontoReservado(),
                 gasto.getMontoAplicado(),

--- a/src/main/java/com/ahumadamob/fnanz/mapper/PeriodoFinancieroMapper.java
+++ b/src/main/java/com/ahumadamob/fnanz/mapper/PeriodoFinancieroMapper.java
@@ -1,0 +1,29 @@
+package com.ahumadamob.fnanz.mapper;
+
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import org.springframework.stereotype.Component;
+
+/**
+ * Conversión entre {@link PeriodoFinanciero} y sus DTOs.
+ */
+@Component
+public class PeriodoFinancieroMapper {
+
+    public PeriodoFinancieroResponseDto toDto(PeriodoFinanciero periodo) {
+        if (periodo == null) {
+            return null;
+        }
+        return new PeriodoFinancieroResponseDto(
+                periodo.getId(),
+                periodo.getNombre(),
+                periodo.getFechaInicio(),
+                periodo.getFechaFin(),
+                periodo.getTipo(),
+                periodo.getDescripcion(),
+                periodo.getCerrado(),
+                periodo.getCreatedAt(),
+                periodo.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ahumadamob/fnanz/mapper/PeriodoFinancieroMapper.java
+++ b/src/main/java/com/ahumadamob/fnanz/mapper/PeriodoFinancieroMapper.java
@@ -1,7 +1,10 @@
 package com.ahumadamob.fnanz.mapper;
 
+import com.ahumadamob.fnanz.dto.PeriodoFinancieroCreateDto;
+import com.ahumadamob.fnanz.dto.PeriodoFinancieroPatchDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 /**
@@ -9,6 +12,42 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class PeriodoFinancieroMapper {
+
+    public PeriodoFinanciero toEntity(PeriodoFinancieroCreateDto dto) {
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        if (dto == null) {
+            return periodo;
+        }
+        periodo.setNombre(dto.getNombre());
+        periodo.setFechaInicio(dto.getFechaInicio());
+        periodo.setFechaFin(dto.getFechaFin());
+        periodo.setTipo(dto.getTipo());
+        periodo.setDescripcion(dto.getDescripcion());
+        if (dto.getCerrado() != null) {
+            periodo.setCerrado(dto.getCerrado());
+        }
+        return periodo;
+    }
+
+    public PeriodoFinanciero toPartialEntity(PeriodoFinancieroPatchDto dto) {
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        updateEntity(dto, periodo);
+        return periodo;
+    }
+
+    public void updateEntity(PeriodoFinancieroPatchDto dto, PeriodoFinanciero periodo) {
+        if (dto == null || periodo == null) {
+            return;
+        }
+        Optional.ofNullable(dto.getNombre()).ifPresent(periodo::setNombre);
+        Optional.ofNullable(dto.getFechaInicio()).ifPresent(periodo::setFechaInicio);
+        Optional.ofNullable(dto.getFechaFin()).ifPresent(periodo::setFechaFin);
+        Optional.ofNullable(dto.getTipo()).ifPresent(periodo::setTipo);
+        Optional.ofNullable(dto.getDescripcion()).ifPresent(periodo::setDescripcion);
+        if (dto.getCerrado() != null) {
+            periodo.setCerrado(dto.getCerrado());
+        }
+    }
 
     public PeriodoFinancieroResponseDto toDto(PeriodoFinanciero periodo) {
         if (periodo == null) {

--- a/src/main/java/com/ahumadamob/fnanz/repository/PeriodoFinancieroRepository.java
+++ b/src/main/java/com/ahumadamob/fnanz/repository/PeriodoFinancieroRepository.java
@@ -1,0 +1,10 @@
+package com.ahumadamob.fnanz.repository;
+
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositorio JPA para {@link PeriodoFinanciero}.
+ */
+public interface PeriodoFinancieroRepository extends JpaRepository<PeriodoFinanciero, Long> {
+}

--- a/src/main/java/com/ahumadamob/fnanz/service/PeriodoFinancieroService.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/PeriodoFinancieroService.java
@@ -1,0 +1,11 @@
+package com.ahumadamob.fnanz.service;
+
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+
+/**
+ * Servicio para operaciones de {@link PeriodoFinanciero}.
+ */
+public interface PeriodoFinancieroService {
+
+    PeriodoFinanciero get(Long id);
+}

--- a/src/main/java/com/ahumadamob/fnanz/service/PeriodoFinancieroService.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/PeriodoFinancieroService.java
@@ -9,7 +9,15 @@ import org.springframework.data.domain.Pageable;
  */
 public interface PeriodoFinancieroService {
 
+    PeriodoFinanciero create(PeriodoFinanciero periodoFinanciero);
+
     Page<PeriodoFinanciero> list(Pageable pageable);
 
     PeriodoFinanciero get(Long id);
+
+    PeriodoFinanciero replace(Long id, PeriodoFinanciero periodoFinanciero);
+
+    PeriodoFinanciero update(Long id, PeriodoFinanciero periodoFinanciero);
+
+    void delete(Long id);
 }

--- a/src/main/java/com/ahumadamob/fnanz/service/PeriodoFinancieroService.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/PeriodoFinancieroService.java
@@ -1,11 +1,15 @@
 package com.ahumadamob.fnanz.service;
 
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Servicio para operaciones de {@link PeriodoFinanciero}.
  */
 public interface PeriodoFinancieroService {
+
+    Page<PeriodoFinanciero> list(Pageable pageable);
 
     PeriodoFinanciero get(Long id);
 }

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImpl.java
@@ -26,7 +26,7 @@ public class GastoReservadoServiceImpl implements GastoReservadoService {
 
     @Override
     public GastoReservado create(GastoReservado gastoReservado) {
-        validateCategoriaAndTipo(gastoReservado);
+        validateCategoriaTipoYPeriodo(gastoReservado);
         return gastoReservadoRepository.save(gastoReservado);
     }
 
@@ -39,10 +39,12 @@ public class GastoReservadoServiceImpl implements GastoReservadoService {
         String like = "%" + q.toLowerCase() + "%";
         Specification<GastoReservado> spec = (root, query, cb) -> {
             var categoriaJoin = root.join("categoria");
+            var periodoJoin = root.join("periodo");
             return cb.or(
                     cb.like(cb.lower(cb.coalesce(root.get("concepto"), "")), like),
                     cb.like(cb.lower(cb.coalesce(root.get("nota"), "")), like),
-                    cb.like(cb.lower(categoriaJoin.get("nombre")), like)
+                    cb.like(cb.lower(categoriaJoin.get("nombre")), like),
+                    cb.like(cb.lower(cb.coalesce(periodoJoin.get("nombre"), "")), like)
             );
         };
         return gastoReservadoRepository.findAll(spec, pageable);
@@ -69,11 +71,8 @@ public class GastoReservadoServiceImpl implements GastoReservadoService {
         if (cambios.getConcepto() != null) {
             gasto.setConcepto(cambios.getConcepto());
         }
-        if (cambios.getPeriodoFecha() != null) {
-            gasto.setPeriodoFecha(cambios.getPeriodoFecha());
-        }
-        if (cambios.getFechaVencimiento() != null) {
-            gasto.setFechaVencimiento(cambios.getFechaVencimiento());
+        if (cambios.getPeriodo() != null) {
+            gasto.setPeriodo(cambios.getPeriodo());
         }
         if (cambios.getEstado() != null) {
             gasto.setEstado(cambios.getEstado());
@@ -88,7 +87,7 @@ public class GastoReservadoServiceImpl implements GastoReservadoService {
             gasto.setNota(cambios.getNota());
         }
 
-        validateCategoriaAndTipo(gasto);
+        validateCategoriaTipoYPeriodo(gasto);
         return gastoReservadoRepository.save(gasto);
     }
 
@@ -100,9 +99,12 @@ public class GastoReservadoServiceImpl implements GastoReservadoService {
         gastoReservadoRepository.deleteById(id);
     }
 
-    private void validateCategoriaAndTipo(GastoReservado gastoReservado) {
+    private void validateCategoriaTipoYPeriodo(GastoReservado gastoReservado) {
         if (gastoReservado.getCategoria() == null) {
             throw new ResourceConflictException("categoriaId", "La categoría asociada no es válida");
+        }
+        if (gastoReservado.getPeriodo() == null) {
+            throw new ResourceConflictException("periodoId", "El periodo asociado no es válido");
         }
         if (gastoReservado.getTipo() != null
                 && gastoReservado.getCategoria().getTipo() != null

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
@@ -1,0 +1,28 @@
+package com.ahumadamob.fnanz.service.jpa;
+
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import com.ahumadamob.fnanz.error.ResourceNotFoundException;
+import com.ahumadamob.fnanz.repository.PeriodoFinancieroRepository;
+import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Implementación JPA del servicio de periodos financieros.
+ */
+@Service
+@Transactional(readOnly = true)
+public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
+
+    private final PeriodoFinancieroRepository periodoFinancieroRepository;
+
+    public PeriodoFinancieroServiceImpl(PeriodoFinancieroRepository periodoFinancieroRepository) {
+        this.periodoFinancieroRepository = periodoFinancieroRepository;
+    }
+
+    @Override
+    public PeriodoFinanciero get(Long id) {
+        return periodoFinancieroRepository.findById(id)
+                .orElseThrow(ResourceNotFoundException::new);
+    }
+}

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Implementación JPA del servicio de periodos financieros.
  */
 @Service
-@Transactional(readOnly = true)
+@Transactional
 public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
 
     private final PeriodoFinancieroRepository periodoFinancieroRepository;
@@ -23,13 +23,79 @@ public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
     }
 
     @Override
+    public PeriodoFinanciero create(PeriodoFinanciero periodoFinanciero) {
+        ensureCerradoFlag(periodoFinanciero);
+        return periodoFinancieroRepository.save(periodoFinanciero);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public Page<PeriodoFinanciero> list(Pageable pageable) {
         return periodoFinancieroRepository.findAll(pageable);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PeriodoFinanciero get(Long id) {
         return periodoFinancieroRepository.findById(id)
                 .orElseThrow(ResourceNotFoundException::new);
+    }
+
+    @Override
+    public PeriodoFinanciero replace(Long id, PeriodoFinanciero periodoFinanciero) {
+        PeriodoFinanciero existente = periodoFinancieroRepository.findById(id)
+                .orElseThrow(ResourceNotFoundException::new);
+
+        existente.setNombre(periodoFinanciero.getNombre());
+        existente.setFechaInicio(periodoFinanciero.getFechaInicio());
+        existente.setFechaFin(periodoFinanciero.getFechaFin());
+        existente.setTipo(periodoFinanciero.getTipo());
+        existente.setDescripcion(periodoFinanciero.getDescripcion());
+        existente.setCerrado(periodoFinanciero.getCerrado());
+
+        ensureCerradoFlag(existente);
+        return periodoFinancieroRepository.save(existente);
+    }
+
+    @Override
+    public PeriodoFinanciero update(Long id, PeriodoFinanciero cambios) {
+        PeriodoFinanciero existente = periodoFinancieroRepository.findById(id)
+                .orElseThrow(ResourceNotFoundException::new);
+
+        if (cambios.getNombre() != null) {
+            existente.setNombre(cambios.getNombre());
+        }
+        if (cambios.getFechaInicio() != null) {
+            existente.setFechaInicio(cambios.getFechaInicio());
+        }
+        if (cambios.getFechaFin() != null) {
+            existente.setFechaFin(cambios.getFechaFin());
+        }
+        if (cambios.getTipo() != null) {
+            existente.setTipo(cambios.getTipo());
+        }
+        if (cambios.getDescripcion() != null) {
+            existente.setDescripcion(cambios.getDescripcion());
+        }
+        if (cambios.getCerrado() != null) {
+            existente.setCerrado(cambios.getCerrado());
+        }
+
+        ensureCerradoFlag(existente);
+        return periodoFinancieroRepository.save(existente);
+    }
+
+    @Override
+    public void delete(Long id) {
+        if (!periodoFinancieroRepository.existsById(id)) {
+            throw new ResourceNotFoundException();
+        }
+        periodoFinancieroRepository.deleteById(id);
+    }
+
+    private void ensureCerradoFlag(PeriodoFinanciero periodoFinanciero) {
+        if (periodoFinanciero.getCerrado() == null) {
+            periodoFinanciero.setCerrado(Boolean.FALSE);
+        }
     }
 }

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
@@ -4,6 +4,8 @@ import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.error.ResourceNotFoundException;
 import com.ahumadamob.fnanz.repository.PeriodoFinancieroRepository;
 import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,11 @@ public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
 
     public PeriodoFinancieroServiceImpl(PeriodoFinancieroRepository periodoFinancieroRepository) {
         this.periodoFinancieroRepository = periodoFinancieroRepository;
+    }
+
+    @Override
+    public Page<PeriodoFinanciero> list(Pageable pageable) {
+        return periodoFinancieroRepository.findAll(pageable);
     }
 
     @Override

--- a/src/test/java/com/ahumadamob/fnanz/controller/GastoReservadoControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/GastoReservadoControllerTest.java
@@ -8,8 +8,10 @@ import com.ahumadamob.fnanz.entity.GastoReservado;
 import com.ahumadamob.fnanz.enums.EstadoReserva;
 import com.ahumadamob.fnanz.enums.TipoFin;
 import com.ahumadamob.fnanz.mapper.GastoReservadoMapper;
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.service.CategoriaFinancieraService;
 import com.ahumadamob.fnanz.service.GastoReservadoService;
+import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -62,14 +64,16 @@ class GastoReservadoControllerTest {
     @MockBean
     private GastoReservadoMapper gastoReservadoMapper;
 
+    @MockBean
+    private PeriodoFinancieroService periodoFinancieroService;
+
     @Test
     void createShouldReturnCreatedResponseWithLocationHeader() throws Exception {
         GastoReservadoCreateDto requestDto = new GastoReservadoCreateDto();
         requestDto.setTipo(TipoFin.EGRESO);
         requestDto.setCategoriaId(5L);
         requestDto.setConcepto("Pago consultoría");
-        requestDto.setPeriodoFecha(LocalDate.of(2024, 5, 1));
-        requestDto.setFechaVencimiento(LocalDate.of(2024, 5, 10));
+        requestDto.setPeriodoId(7L);
         requestDto.setEstado(EstadoReserva.RESERVADO);
         requestDto.setMontoReservado(new BigDecimal("1500.00"));
         requestDto.setMontoAplicado(new BigDecimal("0.00"));
@@ -80,9 +84,16 @@ class GastoReservadoControllerTest {
         categoria.setNombre("Servicios");
         categoria.setTipo(TipoFin.EGRESO);
 
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        periodo.setId(7L);
+        periodo.setNombre("Mayo 2024");
+        periodo.setFechaInicio(LocalDate.of(2024, 5, 1));
+        periodo.setFechaFin(LocalDate.of(2024, 5, 31));
+
         GastoReservado entityToCreate = new GastoReservado();
         entityToCreate.setTipo(TipoFin.EGRESO);
         entityToCreate.setCategoria(categoria);
+        entityToCreate.setPeriodo(periodo);
         entityToCreate.setConcepto("Pago consultoría");
 
         LocalDateTime now = LocalDateTime.of(2024, 5, 2, 12, 0);
@@ -90,8 +101,8 @@ class GastoReservadoControllerTest {
         saved.setId(11L);
         saved.setTipo(TipoFin.EGRESO);
         saved.setCategoria(categoria);
+        saved.setPeriodo(periodo);
         saved.setConcepto("Pago consultoría");
-        saved.setPeriodoFecha(LocalDate.of(2024, 5, 1));
         saved.setEstado(EstadoReserva.RESERVADO);
         saved.setMontoReservado(new BigDecimal("1500.00"));
         saved.setMontoAplicado(BigDecimal.ZERO);
@@ -105,8 +116,10 @@ class GastoReservadoControllerTest {
                 5L,
                 "Servicios",
                 "Pago consultoría",
+                7L,
+                "Mayo 2024",
                 LocalDate.of(2024, 5, 1),
-                LocalDate.of(2024, 5, 10),
+                LocalDate.of(2024, 5, 31),
                 EstadoReserva.RESERVADO,
                 new BigDecimal("1500.00"),
                 BigDecimal.ZERO,
@@ -116,7 +129,8 @@ class GastoReservadoControllerTest {
         );
 
         when(categoriaFinancieraService.get(5L)).thenReturn(categoria);
-        when(gastoReservadoMapper.toEntity(ArgumentMatchers.any(GastoReservadoCreateDto.class), eq(categoria)))
+        when(periodoFinancieroService.get(7L)).thenReturn(periodo);
+        when(gastoReservadoMapper.toEntity(ArgumentMatchers.any(GastoReservadoCreateDto.class), eq(categoria), eq(periodo)))
                 .thenReturn(entityToCreate);
         when(gastoReservadoService.create(entityToCreate)).thenReturn(saved);
         when(gastoReservadoMapper.toDto(saved)).thenReturn(responseDto);
@@ -131,15 +145,20 @@ class GastoReservadoControllerTest {
                 .andExpect(jsonPath("$.data.tipo").value(TipoFin.EGRESO.name()))
                 .andExpect(jsonPath("$.data.categoriaId").value(5L))
                 .andExpect(jsonPath("$.data.concepto").value("Pago consultoría"))
+                .andExpect(jsonPath("$.data.periodoId").value(7L))
+                .andExpect(jsonPath("$.data.periodoNombre").value("Mayo 2024"))
+                .andExpect(jsonPath("$.data.periodoFechaInicio").value("2024-05-01"))
+                .andExpect(jsonPath("$.data.periodoFechaFin").value("2024-05-31"))
                 .andExpect(jsonPath("$.data.estado").value(EstadoReserva.RESERVADO.name()))
                 .andExpect(jsonPath("$.data.montoReservado").value(1500.00))
                 .andExpect(jsonPath("$.timestamp").exists());
 
         verify(categoriaFinancieraService).get(5L);
-        verify(gastoReservadoMapper).toEntity(ArgumentMatchers.any(GastoReservadoCreateDto.class), eq(categoria));
+        verify(periodoFinancieroService).get(7L);
+        verify(gastoReservadoMapper).toEntity(ArgumentMatchers.any(GastoReservadoCreateDto.class), eq(categoria), eq(periodo));
         verify(gastoReservadoService).create(entityToCreate);
         verify(gastoReservadoMapper).toDto(saved);
-        verifyNoMoreInteractions(gastoReservadoService, categoriaFinancieraService, gastoReservadoMapper);
+        verifyNoMoreInteractions(gastoReservadoService, categoriaFinancieraService, gastoReservadoMapper, periodoFinancieroService);
     }
 
     @Test
@@ -170,8 +189,10 @@ class GastoReservadoControllerTest {
                 5L,
                 "Servicios",
                 "Pago consultoría",
+                3L,
+                "Mayo 2024",
                 LocalDate.of(2024, 5, 1),
-                LocalDate.of(2024, 5, 10),
+                LocalDate.of(2024, 5, 31),
                 EstadoReserva.RESERVADO,
                 new BigDecimal("1500.00"),
                 BigDecimal.ZERO,
@@ -186,8 +207,10 @@ class GastoReservadoControllerTest {
                 6L,
                 "Salarios",
                 "Ingreso mensual",
-                LocalDate.of(2024, 5, 1),
-                null,
+                4L,
+                "2024",
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 12, 31),
                 EstadoReserva.APLICADO,
                 new BigDecimal("5000.00"),
                 new BigDecimal("5000.00"),
@@ -220,7 +243,7 @@ class GastoReservadoControllerTest {
         verify(gastoReservadoService).list(ArgumentMatchers.isNull(), any(Pageable.class));
         verify(gastoReservadoMapper).toDto(egreso);
         verify(gastoReservadoMapper).toDto(ingreso);
-        verifyNoMoreInteractions(gastoReservadoService, gastoReservadoMapper, categoriaFinancieraService);
+        verifyNoMoreInteractions(gastoReservadoService, gastoReservadoMapper, categoriaFinancieraService, periodoFinancieroService);
     }
 
     @Test
@@ -235,14 +258,22 @@ class GastoReservadoControllerTest {
         gasto.setCategoria(categoria);
         gasto.setTipo(TipoFin.EGRESO);
 
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        periodo.setId(8L);
+        periodo.setNombre("Junio 2024");
+        periodo.setFechaInicio(LocalDate.of(2024, 6, 1));
+        periodo.setFechaFin(LocalDate.of(2024, 6, 30));
+
         GastoReservadoResponseDto dto = new GastoReservadoResponseDto(
                 30L,
                 TipoFin.EGRESO,
                 7L,
                 "Honorarios",
                 "Pago asesoría",
+                8L,
+                "Junio 2024",
                 LocalDate.of(2024, 6, 1),
-                LocalDate.of(2024, 6, 10),
+                LocalDate.of(2024, 6, 30),
                 EstadoReserva.RESERVADO,
                 new BigDecimal("1200.00"),
                 null,
@@ -262,7 +293,7 @@ class GastoReservadoControllerTest {
 
         verify(gastoReservadoService).get(30L);
         verify(gastoReservadoMapper).toDto(gasto);
-        verifyNoMoreInteractions(gastoReservadoService, gastoReservadoMapper, categoriaFinancieraService);
+        verifyNoMoreInteractions(gastoReservadoService, gastoReservadoMapper, categoriaFinancieraService, periodoFinancieroService);
     }
 
     @Test
@@ -270,6 +301,7 @@ class GastoReservadoControllerTest {
         GastoReservadoPatchDto patchDto = new GastoReservadoPatchDto();
         patchDto.setCategoriaId(9L);
         patchDto.setConcepto("Actualizado");
+        patchDto.setPeriodoId(12L);
         patchDto.setMontoReservado(new BigDecimal("1800.00"));
 
         CategoriaFinanciera categoria = new CategoriaFinanciera();
@@ -277,15 +309,23 @@ class GastoReservadoControllerTest {
         categoria.setNombre("Servicios");
         categoria.setTipo(TipoFin.EGRESO);
 
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        periodo.setId(12L);
+        periodo.setNombre("Julio 2024");
+        periodo.setFechaInicio(LocalDate.of(2024, 7, 1));
+        periodo.setFechaFin(LocalDate.of(2024, 7, 31));
+
         GastoReservado cambios = new GastoReservado();
         cambios.setCategoria(categoria);
         cambios.setConcepto("Actualizado");
+        cambios.setPeriodo(periodo);
 
         GastoReservado updated = new GastoReservado();
         updated.setId(40L);
         updated.setCategoria(categoria);
         updated.setTipo(TipoFin.EGRESO);
         updated.setConcepto("Actualizado");
+        updated.setPeriodo(periodo);
         updated.setMontoReservado(new BigDecimal("1800.00"));
 
         GastoReservadoResponseDto responseDto = new GastoReservadoResponseDto(
@@ -294,8 +334,10 @@ class GastoReservadoControllerTest {
                 9L,
                 "Servicios",
                 "Actualizado",
+                12L,
+                "Julio 2024",
                 LocalDate.of(2024, 7, 1),
-                null,
+                LocalDate.of(2024, 7, 31),
                 EstadoReserva.RESERVADO,
                 new BigDecimal("1800.00"),
                 null,
@@ -305,7 +347,8 @@ class GastoReservadoControllerTest {
         );
 
         when(categoriaFinancieraService.get(9L)).thenReturn(categoria);
-        when(gastoReservadoMapper.toPartialEntity(ArgumentMatchers.any(GastoReservadoPatchDto.class), eq(categoria)))
+        when(periodoFinancieroService.get(12L)).thenReturn(periodo);
+        when(gastoReservadoMapper.toPartialEntity(ArgumentMatchers.any(GastoReservadoPatchDto.class), eq(categoria), eq(periodo)))
                 .thenReturn(cambios);
         when(gastoReservadoService.update(40L, cambios)).thenReturn(updated);
         when(gastoReservadoMapper.toDto(updated)).thenReturn(responseDto);
@@ -316,14 +359,16 @@ class GastoReservadoControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(40L))
                 .andExpect(jsonPath("$.data.categoriaId").value(9L))
+                .andExpect(jsonPath("$.data.periodoId").value(12L))
                 .andExpect(jsonPath("$.data.montoReservado").value(1800.00))
                 .andExpect(jsonPath("$.timestamp").exists());
 
         verify(categoriaFinancieraService).get(9L);
-        verify(gastoReservadoMapper).toPartialEntity(ArgumentMatchers.any(GastoReservadoPatchDto.class), eq(categoria));
+        verify(periodoFinancieroService).get(12L);
+        verify(gastoReservadoMapper).toPartialEntity(ArgumentMatchers.any(GastoReservadoPatchDto.class), eq(categoria), eq(periodo));
         verify(gastoReservadoService).update(40L, cambios);
         verify(gastoReservadoMapper).toDto(updated);
-        verifyNoMoreInteractions(gastoReservadoService, categoriaFinancieraService, gastoReservadoMapper);
+        verifyNoMoreInteractions(gastoReservadoService, categoriaFinancieraService, gastoReservadoMapper, periodoFinancieroService);
     }
 
     @Test
@@ -335,6 +380,6 @@ class GastoReservadoControllerTest {
 
         verify(gastoReservadoService).delete(55L);
         verifyNoMoreInteractions(gastoReservadoService);
-        verifyNoMoreInteractions(categoriaFinancieraService, gastoReservadoMapper);
-    }
+        verifyNoMoreInteractions(categoriaFinancieraService, gastoReservadoMapper, periodoFinancieroService);
+}
 }

--- a/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
@@ -1,0 +1,79 @@
+package com.ahumadamob.fnanz.controller;
+
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import com.ahumadamob.fnanz.mapper.PeriodoFinancieroMapper;
+import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PeriodoFinancieroController.class)
+class PeriodoFinancieroControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PeriodoFinancieroService periodoFinancieroService;
+
+    @MockBean
+    private PeriodoFinancieroMapper periodoFinancieroMapper;
+
+    @Test
+    void getShouldReturnPeriodo() throws Exception {
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        periodo.setId(4L);
+        periodo.setNombre("Mayo 2024");
+        periodo.setFechaInicio(LocalDate.of(2024, 5, 1));
+        periodo.setFechaFin(LocalDate.of(2024, 5, 31));
+        periodo.setTipo("Mensual");
+        periodo.setDescripcion("Periodo mensual de mayo");
+        periodo.setCerrado(false);
+        LocalDateTime created = LocalDateTime.of(2024, 4, 15, 10, 30);
+        LocalDateTime updated = LocalDateTime.of(2024, 4, 20, 8, 0);
+        periodo.setCreatedAt(created);
+        periodo.setUpdatedAt(updated);
+
+        PeriodoFinancieroResponseDto dto = new PeriodoFinancieroResponseDto(
+                4L,
+                "Mayo 2024",
+                LocalDate.of(2024, 5, 1),
+                LocalDate.of(2024, 5, 31),
+                "Mensual",
+                "Periodo mensual de mayo",
+                false,
+                created,
+                updated
+        );
+
+        when(periodoFinancieroService.get(4L)).thenReturn(periodo);
+        when(periodoFinancieroMapper.toDto(periodo)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/periodos-financieros/{id}", 4L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(4L))
+                .andExpect(jsonPath("$.data.nombre").value("Mayo 2024"))
+                .andExpect(jsonPath("$.data.fechaInicio").value("2024-05-01"))
+                .andExpect(jsonPath("$.data.fechaFin").value("2024-05-31"))
+                .andExpect(jsonPath("$.data.tipo").value("Mensual"))
+                .andExpect(jsonPath("$.data.descripcion").value("Periodo mensual de mayo"))
+                .andExpect(jsonPath("$.data.cerrado").value(false))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(periodoFinancieroService).get(4L);
+        verify(periodoFinancieroMapper).toDto(periodo);
+        verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
+    }
+}

--- a/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
@@ -1,14 +1,19 @@
 package com.ahumadamob.fnanz.controller;
 
+import com.ahumadamob.fnanz.dto.PeriodoFinancieroCreateDto;
+import com.ahumadamob.fnanz.dto.PeriodoFinancieroPatchDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.mapper.PeriodoFinancieroMapper;
 import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -16,14 +21,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import org.mockito.ArgumentCaptor;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,11 +45,62 @@ class PeriodoFinancieroControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @MockBean
     private PeriodoFinancieroService periodoFinancieroService;
 
     @MockBean
     private PeriodoFinancieroMapper periodoFinancieroMapper;
+
+    @Test
+    void createShouldReturnCreatedResponse() throws Exception {
+        PeriodoFinancieroCreateDto dto = new PeriodoFinancieroCreateDto();
+        dto.setNombre("Mayo 2024");
+        dto.setFechaInicio(LocalDate.of(2024, 5, 1));
+        dto.setFechaFin(LocalDate.of(2024, 5, 31));
+        dto.setTipo("Mensual");
+        dto.setDescripcion("Periodo mensual");
+        dto.setCerrado(false);
+
+        PeriodoFinanciero entity = buildPeriodo(null, "Mayo 2024");
+        entity.setFechaInicio(LocalDate.of(2024, 5, 1));
+        entity.setFechaFin(LocalDate.of(2024, 5, 31));
+        entity.setTipo("Mensual");
+        entity.setDescripcion("Periodo mensual");
+        entity.setCerrado(false);
+
+        PeriodoFinanciero saved = buildPeriodo(7L, "Mayo 2024");
+        saved.setFechaInicio(LocalDate.of(2024, 5, 1));
+        saved.setFechaFin(LocalDate.of(2024, 5, 31));
+        saved.setTipo("Mensual");
+        saved.setDescripcion("Periodo mensual");
+        saved.setCerrado(false);
+
+        PeriodoFinancieroResponseDto responseDto = buildDto(saved);
+
+        when(periodoFinancieroMapper.toEntity(ArgumentMatchers.any(PeriodoFinancieroCreateDto.class)))
+                .thenReturn(entity);
+        when(periodoFinancieroService.create(entity)).thenReturn(saved);
+        when(periodoFinancieroMapper.toDto(saved)).thenReturn(responseDto);
+
+        mockMvc.perform(post("/api/periodos-financieros")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "http://localhost/api/periodos-financieros/7"))
+                .andExpect(jsonPath("$.message").value("Periodo financiero creado correctamente"))
+                .andExpect(jsonPath("$.data.id").value(7L))
+                .andExpect(jsonPath("$.data.nombre").value("Mayo 2024"))
+                .andExpect(jsonPath("$.data.fechaInicio").value("2024-05-01"))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(periodoFinancieroMapper).toEntity(ArgumentMatchers.any(PeriodoFinancieroCreateDto.class));
+        verify(periodoFinancieroService).create(entity);
+        verify(periodoFinancieroMapper).toDto(saved);
+        verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
+    }
 
     @Test
     void listShouldReturnPage() throws Exception {
@@ -115,6 +177,96 @@ class PeriodoFinancieroControllerTest {
 
         verify(periodoFinancieroService).get(4L);
         verify(periodoFinancieroMapper).toDto(periodo);
+        verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
+    }
+
+    @Test
+    void replaceShouldReturnUpdatedPeriodo() throws Exception {
+        PeriodoFinancieroCreateDto dto = new PeriodoFinancieroCreateDto();
+        dto.setNombre("Junio 2024");
+        dto.setFechaInicio(LocalDate.of(2024, 6, 1));
+        dto.setFechaFin(LocalDate.of(2024, 6, 30));
+        dto.setTipo("Mensual");
+        dto.setDescripcion("Periodo junio");
+        dto.setCerrado(true);
+
+        PeriodoFinanciero cambios = buildPeriodo(null, "Junio 2024");
+        cambios.setFechaInicio(LocalDate.of(2024, 6, 1));
+        cambios.setFechaFin(LocalDate.of(2024, 6, 30));
+        cambios.setTipo("Mensual");
+        cambios.setDescripcion("Periodo junio");
+        cambios.setCerrado(true);
+
+        PeriodoFinanciero actualizado = buildPeriodo(15L, "Junio 2024");
+        actualizado.setFechaInicio(LocalDate.of(2024, 6, 1));
+        actualizado.setFechaFin(LocalDate.of(2024, 6, 30));
+        actualizado.setTipo("Mensual");
+        actualizado.setDescripcion("Periodo junio");
+        actualizado.setCerrado(true);
+
+        PeriodoFinancieroResponseDto dtoResponse = buildDto(actualizado);
+
+        when(periodoFinancieroMapper.toEntity(ArgumentMatchers.any(PeriodoFinancieroCreateDto.class)))
+                .thenReturn(cambios);
+        when(periodoFinancieroService.replace(15L, cambios)).thenReturn(actualizado);
+        when(periodoFinancieroMapper.toDto(actualizado)).thenReturn(dtoResponse);
+
+        mockMvc.perform(put("/api/periodos-financieros/{id}", 15L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(15L))
+                .andExpect(jsonPath("$.data.nombre").value("Junio 2024"))
+                .andExpect(jsonPath("$.data.cerrado").value(true));
+
+        verify(periodoFinancieroMapper).toEntity(ArgumentMatchers.any(PeriodoFinancieroCreateDto.class));
+        verify(periodoFinancieroService).replace(15L, cambios);
+        verify(periodoFinancieroMapper).toDto(actualizado);
+        verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
+    }
+
+    @Test
+    void patchShouldReturnUpdatedPeriodo() throws Exception {
+        PeriodoFinancieroPatchDto dto = new PeriodoFinancieroPatchDto();
+        dto.setNombre("Abril actualizado");
+        dto.setCerrado(true);
+
+        PeriodoFinanciero cambios = new PeriodoFinanciero();
+        cambios.setNombre("Abril actualizado");
+        cambios.setCerrado(true);
+
+        PeriodoFinanciero actualizado = buildPeriodo(9L, "Abril actualizado");
+        actualizado.setCerrado(true);
+
+        PeriodoFinancieroResponseDto responseDto = buildDto(actualizado);
+
+        when(periodoFinancieroMapper.toPartialEntity(ArgumentMatchers.any(PeriodoFinancieroPatchDto.class)))
+                .thenReturn(cambios);
+        when(periodoFinancieroService.update(9L, cambios)).thenReturn(actualizado);
+        when(periodoFinancieroMapper.toDto(actualizado)).thenReturn(responseDto);
+
+        mockMvc.perform(patch("/api/periodos-financieros/{id}", 9L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(9L))
+                .andExpect(jsonPath("$.data.nombre").value("Abril actualizado"))
+                .andExpect(jsonPath("$.data.cerrado").value(true));
+
+        verify(periodoFinancieroMapper).toPartialEntity(ArgumentMatchers.any(PeriodoFinancieroPatchDto.class));
+        verify(periodoFinancieroService).update(9L, cambios);
+        verify(periodoFinancieroMapper).toDto(actualizado);
+        verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
+    }
+
+    @Test
+    void deleteShouldReturnNoContent() throws Exception {
+        doNothing().when(periodoFinancieroService).delete(22L);
+
+        mockMvc.perform(delete("/api/periodos-financieros/{id}", 22L))
+                .andExpect(status().isNoContent());
+
+        verify(periodoFinancieroService).delete(22L);
         verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
     }
 

--- a/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
@@ -6,16 +6,25 @@ import com.ahumadamob.fnanz.mapper.PeriodoFinancieroMapper;
 import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.mockito.ArgumentCaptor;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -30,6 +39,38 @@ class PeriodoFinancieroControllerTest {
 
     @MockBean
     private PeriodoFinancieroMapper periodoFinancieroMapper;
+
+    @Test
+    void listShouldReturnPage() throws Exception {
+        PeriodoFinanciero periodo1 = buildPeriodo(3L, "Abril 2024");
+        PeriodoFinanciero periodo2 = buildPeriodo(4L, "Mayo 2024");
+        Page<PeriodoFinanciero> page = new PageImpl<>(List.of(periodo1, periodo2), PageRequest.of(0, 10), 2);
+
+        PeriodoFinancieroResponseDto dto1 = buildDto(periodo1);
+        PeriodoFinancieroResponseDto dto2 = buildDto(periodo2);
+
+        when(periodoFinancieroService.list(PageRequest.of(0, 10))).thenReturn(page);
+        when(periodoFinancieroMapper.toDto(periodo1)).thenReturn(dto1);
+        when(periodoFinancieroMapper.toDto(periodo2)).thenReturn(dto2);
+
+        mockMvc.perform(get("/api/periodos-financieros")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Total-Count", "2"))
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].id").value(3L))
+                .andExpect(jsonPath("$.data[0].nombre").value("Abril 2024"))
+                .andExpect(jsonPath("$.data[1].id").value(4L))
+                .andExpect(jsonPath("$.data[1].nombre").value("Mayo 2024"));
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(periodoFinancieroService).list(captor.capture());
+        Assertions.assertThat(captor.getValue()).isEqualTo(PageRequest.of(0, 10));
+        verify(periodoFinancieroMapper).toDto(periodo1);
+        verify(periodoFinancieroMapper).toDto(periodo2);
+        verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
+    }
 
     @Test
     void getShouldReturnPeriodo() throws Exception {
@@ -75,5 +116,33 @@ class PeriodoFinancieroControllerTest {
         verify(periodoFinancieroService).get(4L);
         verify(periodoFinancieroMapper).toDto(periodo);
         verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
+    }
+
+    private PeriodoFinanciero buildPeriodo(Long id, String nombre) {
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        periodo.setId(id);
+        periodo.setNombre(nombre);
+        periodo.setFechaInicio(LocalDate.of(2024, 4, 1));
+        periodo.setFechaFin(LocalDate.of(2024, 4, 30));
+        periodo.setTipo("Mensual");
+        periodo.setDescripcion("Periodo mensual");
+        periodo.setCerrado(false);
+        periodo.setCreatedAt(LocalDateTime.of(2024, 3, 1, 0, 0));
+        periodo.setUpdatedAt(LocalDateTime.of(2024, 3, 2, 0, 0));
+        return periodo;
+    }
+
+    private PeriodoFinancieroResponseDto buildDto(PeriodoFinanciero periodo) {
+        return new PeriodoFinancieroResponseDto(
+                periodo.getId(),
+                periodo.getNombre(),
+                periodo.getFechaInicio(),
+                periodo.getFechaFin(),
+                periodo.getTipo(),
+                periodo.getDescripcion(),
+                periodo.getCerrado(),
+                periodo.getCreatedAt(),
+                periodo.getUpdatedAt()
+        );
     }
 }

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImplTest.java
@@ -2,6 +2,7 @@ package com.ahumadamob.fnanz.service.jpa;
 
 import com.ahumadamob.fnanz.entity.CategoriaFinanciera;
 import com.ahumadamob.fnanz.entity.GastoReservado;
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.enums.EstadoReserva;
 import com.ahumadamob.fnanz.enums.TipoFin;
 import com.ahumadamob.fnanz.error.ResourceConflictException;
@@ -44,10 +45,11 @@ class GastoReservadoServiceImplTest {
     @Test
     void createShouldPersistWhenTipoMatchesCategoria() {
         CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
-        GastoReservado toCreate = buildGasto(null, TipoFin.EGRESO, categoria);
+        PeriodoFinanciero periodo = buildPeriodo(1L, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31));
+        GastoReservado toCreate = buildGasto(null, TipoFin.EGRESO, categoria, periodo);
         toCreate.setEstado(EstadoReserva.RESERVADO);
 
-        GastoReservado saved = buildGasto(10L, TipoFin.EGRESO, categoria);
+        GastoReservado saved = buildGasto(10L, TipoFin.EGRESO, categoria, periodo);
         saved.setEstado(EstadoReserva.RESERVADO);
 
         when(gastoReservadoRepository.save(toCreate)).thenReturn(saved);
@@ -60,7 +62,8 @@ class GastoReservadoServiceImplTest {
     @Test
     void createShouldThrowConflictWhenTipoDiffersFromCategoria() {
         CategoriaFinanciera categoria = buildCategoria(1L, "Salario", TipoFin.INGRESO);
-        GastoReservado toCreate = buildGasto(null, TipoFin.EGRESO, categoria);
+        PeriodoFinanciero periodo = buildPeriodo(1L, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31));
+        GastoReservado toCreate = buildGasto(null, TipoFin.EGRESO, categoria, periodo);
 
         assertThatThrownBy(() -> service.create(toCreate))
                 .isInstanceOf(ResourceConflictException.class);
@@ -70,7 +73,8 @@ class GastoReservadoServiceImplTest {
     @Test
     void getShouldReturnGastoWhenExists() {
         CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
-        GastoReservado gasto = buildGasto(5L, TipoFin.EGRESO, categoria);
+        PeriodoFinanciero periodo = buildPeriodo(1L, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31));
+        GastoReservado gasto = buildGasto(5L, TipoFin.EGRESO, categoria, periodo);
         when(gastoReservadoRepository.findById(5L)).thenReturn(Optional.of(gasto));
 
         GastoReservado result = service.get(5L);
@@ -90,7 +94,9 @@ class GastoReservadoServiceImplTest {
     void updateShouldApplyProvidedChanges() {
         CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
         CategoriaFinanciera nuevaCategoria = buildCategoria(2L, "Honorarios", TipoFin.EGRESO);
-        GastoReservado existing = buildGasto(8L, TipoFin.EGRESO, categoria);
+        PeriodoFinanciero periodo = buildPeriodo(1L, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31));
+        PeriodoFinanciero nuevoPeriodo = buildPeriodo(2L, LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30));
+        GastoReservado existing = buildGasto(8L, TipoFin.EGRESO, categoria, periodo);
         existing.setConcepto("Pago consultoría");
         existing.setNota("Mensual");
 
@@ -98,8 +104,7 @@ class GastoReservadoServiceImplTest {
         cambios.setTipo(TipoFin.EGRESO);
         cambios.setCategoria(nuevaCategoria);
         cambios.setConcepto("Pago asesoría");
-        cambios.setPeriodoFecha(LocalDate.of(2024, 6, 1));
-        cambios.setFechaVencimiento(LocalDate.of(2024, 6, 10));
+        cambios.setPeriodo(nuevoPeriodo);
         cambios.setEstado(EstadoReserva.APLICADO);
         cambios.setMontoReservado(new BigDecimal("2000.00"));
         cambios.setMontoAplicado(new BigDecimal("1800.00"));
@@ -112,8 +117,7 @@ class GastoReservadoServiceImplTest {
 
         assertThat(result.getCategoria()).isSameAs(nuevaCategoria);
         assertThat(result.getConcepto()).isEqualTo("Pago asesoría");
-        assertThat(result.getPeriodoFecha()).isEqualTo(LocalDate.of(2024, 6, 1));
-        assertThat(result.getFechaVencimiento()).isEqualTo(LocalDate.of(2024, 6, 10));
+        assertThat(result.getPeriodo()).isSameAs(nuevoPeriodo);
         assertThat(result.getEstado()).isEqualTo(EstadoReserva.APLICADO);
         assertThat(result.getMontoReservado()).isEqualByComparingTo("2000.00");
         assertThat(result.getMontoAplicado()).isEqualByComparingTo("1800.00");
@@ -123,7 +127,8 @@ class GastoReservadoServiceImplTest {
     @Test
     void updateShouldThrowConflictWhenTipoDoesNotMatchCategoria() {
         CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
-        GastoReservado existing = buildGasto(8L, TipoFin.EGRESO, categoria);
+        PeriodoFinanciero periodo = buildPeriodo(1L, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31));
+        GastoReservado existing = buildGasto(8L, TipoFin.EGRESO, categoria, periodo);
 
         GastoReservado cambios = new GastoReservado();
         cambios.setTipo(TipoFin.INGRESO);
@@ -139,6 +144,7 @@ class GastoReservadoServiceImplTest {
     void updateShouldThrowWhenGastoDoesNotExist() {
         GastoReservado cambios = new GastoReservado();
         cambios.setTipo(TipoFin.EGRESO);
+        cambios.setPeriodo(buildPeriodo(1L, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31)));
 
         when(gastoReservadoRepository.findById(8L)).thenReturn(Optional.empty());
 
@@ -200,12 +206,22 @@ class GastoReservadoServiceImplTest {
         return categoria;
     }
 
-    private GastoReservado buildGasto(Long id, TipoFin tipo, CategoriaFinanciera categoria) {
+    private PeriodoFinanciero buildPeriodo(Long id, LocalDate inicio, LocalDate fin) {
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        periodo.setId(id);
+        periodo.setNombre("Periodo " + id);
+        periodo.setFechaInicio(inicio);
+        periodo.setFechaFin(fin);
+        periodo.setCerrado(false);
+        return periodo;
+    }
+
+    private GastoReservado buildGasto(Long id, TipoFin tipo, CategoriaFinanciera categoria, PeriodoFinanciero periodo) {
         GastoReservado gasto = new GastoReservado();
         gasto.setId(id);
         gasto.setTipo(tipo);
         gasto.setCategoria(categoria);
-        gasto.setPeriodoFecha(LocalDate.of(2024, 5, 1));
+        gasto.setPeriodo(periodo);
         gasto.setMontoReservado(new BigDecimal("1000.00"));
         return gasto;
     }

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
@@ -1,0 +1,57 @@
+package com.ahumadamob.fnanz.service.jpa;
+
+import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import com.ahumadamob.fnanz.error.ResourceNotFoundException;
+import com.ahumadamob.fnanz.repository.PeriodoFinancieroRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PeriodoFinancieroServiceImplTest {
+
+    @Mock
+    private PeriodoFinancieroRepository periodoFinancieroRepository;
+
+    @InjectMocks
+    private PeriodoFinancieroServiceImpl service;
+
+    @Test
+    void getShouldReturnPeriodoWhenExists() {
+        PeriodoFinanciero periodo = buildPeriodo(5L, "Mayo 2024",
+                LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31));
+        when(periodoFinancieroRepository.findById(5L)).thenReturn(Optional.of(periodo));
+
+        PeriodoFinanciero result = service.get(5L);
+
+        assertThat(result).isSameAs(periodo);
+        verify(periodoFinancieroRepository).findById(5L);
+    }
+
+    @Test
+    void getShouldThrowWhenPeriodoDoesNotExist() {
+        when(periodoFinancieroRepository.findById(9L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.get(9L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    private PeriodoFinanciero buildPeriodo(Long id, String nombre, LocalDate inicio, LocalDate fin) {
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        periodo.setId(id);
+        periodo.setNombre(nombre);
+        periodo.setFechaInicio(inicio);
+        periodo.setFechaFin(fin);
+        periodo.setCerrado(false);
+        return periodo;
+    }
+}

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
@@ -4,12 +4,17 @@ import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.error.ResourceNotFoundException;
 import com.ahumadamob.fnanz.repository.PeriodoFinancieroRepository;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,6 +40,20 @@ class PeriodoFinancieroServiceImplTest {
 
         assertThat(result).isSameAs(periodo);
         verify(periodoFinancieroRepository).findById(5L);
+    }
+
+    @Test
+    void listShouldDelegateToRepository() {
+        Pageable pageable = PageRequest.of(1, 20);
+        Page<PeriodoFinanciero> expected = new PageImpl<>(List.of(
+                buildPeriodo(10L, "Junio 2024", LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30))
+        ), pageable, 1);
+        when(periodoFinancieroRepository.findAll(pageable)).thenReturn(expected);
+
+        Page<PeriodoFinanciero> result = service.list(pageable);
+
+        assertThat(result).isSameAs(expected);
+        verify(periodoFinancieroRepository).findAll(pageable);
     }
 
     @Test

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +30,21 @@ class PeriodoFinancieroServiceImplTest {
 
     @InjectMocks
     private PeriodoFinancieroServiceImpl service;
+
+    @Test
+    void createShouldPersistPeriodoWithDefaultCerradoWhenNull() {
+        PeriodoFinanciero periodo = buildPeriodo(null, "Mayo 2024",
+                LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31));
+        periodo.setCerrado(null);
+
+        when(periodoFinancieroRepository.save(periodo)).thenReturn(periodo);
+
+        PeriodoFinanciero result = service.create(periodo);
+
+        assertThat(result).isSameAs(periodo);
+        assertThat(periodo.getCerrado()).isFalse();
+        verify(periodoFinancieroRepository).save(periodo);
+    }
 
     @Test
     void getShouldReturnPeriodoWhenExists() {
@@ -62,6 +78,74 @@ class PeriodoFinancieroServiceImplTest {
 
         assertThatThrownBy(() -> service.get(9L))
                 .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void replaceShouldOverwriteAllFields() {
+        PeriodoFinanciero existente = buildPeriodo(12L, "Abril", LocalDate.of(2024, 4, 1), LocalDate.of(2024, 4, 30));
+        existente.setDescripcion("Periodo original");
+        existente.setTipo("Mensual");
+
+        PeriodoFinanciero cambios = buildPeriodo(null, "Mayo", LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31));
+        cambios.setDescripcion("Periodo reemplazado");
+        cambios.setTipo("Mensual");
+        cambios.setCerrado(true);
+
+        when(periodoFinancieroRepository.findById(12L)).thenReturn(Optional.of(existente));
+        when(periodoFinancieroRepository.save(existente)).thenReturn(existente);
+
+        PeriodoFinanciero result = service.replace(12L, cambios);
+
+        assertThat(result.getNombre()).isEqualTo("Mayo");
+        assertThat(result.getFechaInicio()).isEqualTo(LocalDate.of(2024, 5, 1));
+        assertThat(result.getFechaFin()).isEqualTo(LocalDate.of(2024, 5, 31));
+        assertThat(result.getDescripcion()).isEqualTo("Periodo reemplazado");
+        assertThat(result.getTipo()).isEqualTo("Mensual");
+        assertThat(result.getCerrado()).isTrue();
+        verify(periodoFinancieroRepository).save(existente);
+    }
+
+    @Test
+    void updateShouldApplyOnlyProvidedFields() {
+        PeriodoFinanciero existente = buildPeriodo(20L, "Junio", LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30));
+        existente.setDescripcion("Descripcion original");
+        existente.setTipo("Mensual");
+
+        PeriodoFinanciero cambios = new PeriodoFinanciero();
+        cambios.setNombre("Junio actualizado");
+        cambios.setDescripcion("Descripcion nueva");
+
+        when(periodoFinancieroRepository.findById(20L)).thenReturn(Optional.of(existente));
+        when(periodoFinancieroRepository.save(existente)).thenReturn(existente);
+
+        PeriodoFinanciero result = service.update(20L, cambios);
+
+        assertThat(result.getNombre()).isEqualTo("Junio actualizado");
+        assertThat(result.getDescripcion()).isEqualTo("Descripcion nueva");
+        assertThat(result.getTipo()).isEqualTo("Mensual");
+        assertThat(result.getFechaInicio()).isEqualTo(LocalDate.of(2024, 6, 1));
+        verify(periodoFinancieroRepository).save(existente);
+    }
+
+    @Test
+    void deleteShouldRemoveExistingPeriodo() {
+        when(periodoFinancieroRepository.existsById(30L)).thenReturn(true);
+
+        service.delete(30L);
+
+        verify(periodoFinancieroRepository).existsById(30L);
+        verify(periodoFinancieroRepository).deleteById(30L);
+    }
+
+    @Test
+    void deleteShouldThrowWhenPeriodoDoesNotExist() {
+        when(periodoFinancieroRepository.existsById(40L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.delete(40L))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(periodoFinancieroRepository).existsById(40L);
+        verify(periodoFinancieroRepository, never()).deleteById(40L);
     }
 
     private PeriodoFinanciero buildPeriodo(Long id, String nombre, LocalDate inicio, LocalDate fin) {


### PR DESCRIPTION
## Summary
- add the PeriodoFinanciero entity plus repository and service to reuse period date ranges
- refactor GastoReservado to reference financial periods and expose them through DTOs, mapper, controller and service validation
- update reserved expense unit tests to exercise the new period relationship and search specification

## Testing
- mvn test *(fails: cannot download Spring Boot parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dd26addb88832f97e5bded5295eb4e