### PR TITLE
Agregar endpoint de resumen de reservas por periodo financiero

### DIFF
--- a/src/main/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroController.java
+++ b/src/main/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroController.java
@@ -3,6 +3,7 @@ package com.ahumadamob.fnanz.controller;
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroCreateDto;
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroPatchDto;
 import com.ahumadamob.fnanz.dto.response.ApiResponseSuccessDto;
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroReservasResumenDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.mapper.PeriodoFinancieroMapper;
@@ -64,6 +65,13 @@ public class PeriodoFinancieroController {
     public ApiResponseSuccessDto<PeriodoFinancieroResponseDto> get(@PathVariable Long id) {
         PeriodoFinanciero periodo = periodoFinancieroService.get(id);
         return ok(periodoFinancieroMapper.toDto(periodo));
+    }
+
+    @GetMapping("/{id}/reservas-resumen")
+    public ApiResponseSuccessDto<PeriodoFinancieroReservasResumenDto> getResumenReservas(
+            @PathVariable Long id) {
+        PeriodoFinancieroReservasResumenDto resumen = periodoFinancieroService.obtenerResumenReservas(id);
+        return ok(resumen);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/ahumadamob/fnanz/dto/response/GastoReservadoCategoriaResumenDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/GastoReservadoCategoriaResumenDto.java
@@ -1,0 +1,31 @@
+package com.ahumadamob.fnanz.dto.response;
+
+import com.ahumadamob.fnanz.enums.TipoFin;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO con la suma de montos reservados y aplicados por categoría.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GastoReservadoCategoriaResumenDto {
+
+    private Long categoriaId;
+
+    private String categoriaNombre;
+
+    private TipoFin tipo;
+
+    private Integer orden;
+
+    private BigDecimal montoReservado;
+
+    private BigDecimal montoAplicado;
+}
+

--- a/src/main/java/com/ahumadamob/fnanz/dto/response/GastoReservadoTotalesDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/GastoReservadoTotalesDto.java
@@ -1,0 +1,22 @@
+package com.ahumadamob.fnanz.dto.response;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO para representar totales de montos reservados y aplicados.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GastoReservadoTotalesDto {
+
+    private BigDecimal montoReservado;
+
+    private BigDecimal montoAplicado;
+}
+

--- a/src/main/java/com/ahumadamob/fnanz/dto/response/PeriodoFinancieroReservasResumenDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/PeriodoFinancieroReservasResumenDto.java
@@ -1,0 +1,28 @@
+package com.ahumadamob.fnanz.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO que contiene el resumen de reservas por categoría para un periodo financiero.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PeriodoFinancieroReservasResumenDto {
+
+    private List<GastoReservadoCategoriaResumenDto> ingresos;
+
+    private GastoReservadoTotalesDto totalIngresos;
+
+    private List<GastoReservadoCategoriaResumenDto> egresos;
+
+    private GastoReservadoTotalesDto totalEgresos;
+
+    private GastoReservadoTotalesDto totalGeneral;
+}
+

--- a/src/main/java/com/ahumadamob/fnanz/repository/GastoReservadoRepository.java
+++ b/src/main/java/com/ahumadamob/fnanz/repository/GastoReservadoRepository.java
@@ -1,12 +1,29 @@
 package com.ahumadamob.fnanz.repository;
 
 import com.ahumadamob.fnanz.entity.GastoReservado;
+import com.ahumadamob.fnanz.repository.projection.GastoReservadoCategoriaResumenProjection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Repositorio JPA para la entidad {@link GastoReservado}.
  */
 public interface GastoReservadoRepository extends JpaRepository<GastoReservado, Long>,
         JpaSpecificationExecutor<GastoReservado> {
+
+    @Query("""
+            select gr.categoria.id as categoriaId,
+                   gr.categoria.nombre as categoriaNombre,
+                   gr.categoria.tipo as tipo,
+                   gr.categoria.orden as categoriaOrden,
+                   coalesce(sum(gr.montoReservado), 0) as totalMontoReservado,
+                   coalesce(sum(gr.montoAplicado), 0) as totalMontoAplicado
+            from GastoReservado gr
+            where gr.periodo.id = :periodoId
+            group by gr.categoria.id, gr.categoria.nombre, gr.categoria.tipo, gr.categoria.orden
+            """)
+    List<GastoReservadoCategoriaResumenProjection> sumByPeriodoId(@Param("periodoId") Long periodoId);
 }

--- a/src/main/java/com/ahumadamob/fnanz/repository/projection/GastoReservadoCategoriaResumenProjection.java
+++ b/src/main/java/com/ahumadamob/fnanz/repository/projection/GastoReservadoCategoriaResumenProjection.java
@@ -1,0 +1,23 @@
+package com.ahumadamob.fnanz.repository.projection;
+
+import com.ahumadamob.fnanz.enums.TipoFin;
+import java.math.BigDecimal;
+
+/**
+ * Proyección para obtener los totales de reservas agrupados por categoría.
+ */
+public interface GastoReservadoCategoriaResumenProjection {
+
+    Long getCategoriaId();
+
+    String getCategoriaNombre();
+
+    TipoFin getTipo();
+
+    Integer getCategoriaOrden();
+
+    BigDecimal getTotalMontoReservado();
+
+    BigDecimal getTotalMontoAplicado();
+}
+

--- a/src/main/java/com/ahumadamob/fnanz/service/PeriodoFinancieroService.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/PeriodoFinancieroService.java
@@ -1,5 +1,6 @@
 package com.ahumadamob.fnanz.service;
 
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroReservasResumenDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,4 +21,6 @@ public interface PeriodoFinancieroService {
     PeriodoFinanciero update(Long id, PeriodoFinanciero periodoFinanciero);
 
     void delete(Long id);
+
+    PeriodoFinancieroReservasResumenDto obtenerResumenReservas(Long id);
 }

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
@@ -1,9 +1,19 @@
 package com.ahumadamob.fnanz.service.jpa;
 
+import com.ahumadamob.fnanz.dto.response.GastoReservadoCategoriaResumenDto;
+import com.ahumadamob.fnanz.dto.response.GastoReservadoTotalesDto;
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroReservasResumenDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.error.ResourceNotFoundException;
+import com.ahumadamob.fnanz.enums.TipoFin;
+import com.ahumadamob.fnanz.repository.GastoReservadoRepository;
 import com.ahumadamob.fnanz.repository.PeriodoFinancieroRepository;
+import com.ahumadamob.fnanz.repository.projection.GastoReservadoCategoriaResumenProjection;
 import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,9 +27,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
 
     private final PeriodoFinancieroRepository periodoFinancieroRepository;
+    private final GastoReservadoRepository gastoReservadoRepository;
 
-    public PeriodoFinancieroServiceImpl(PeriodoFinancieroRepository periodoFinancieroRepository) {
+    public PeriodoFinancieroServiceImpl(PeriodoFinancieroRepository periodoFinancieroRepository,
+                                        GastoReservadoRepository gastoReservadoRepository) {
         this.periodoFinancieroRepository = periodoFinancieroRepository;
+        this.gastoReservadoRepository = gastoReservadoRepository;
     }
 
     @Override
@@ -93,9 +106,80 @@ public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
         periodoFinancieroRepository.deleteById(id);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public PeriodoFinancieroReservasResumenDto obtenerResumenReservas(Long id) {
+        if (!periodoFinancieroRepository.existsById(id)) {
+            throw new ResourceNotFoundException();
+        }
+
+        List<GastoReservadoCategoriaResumenProjection> resumenes =
+                gastoReservadoRepository.sumByPeriodoId(id);
+
+        List<GastoReservadoCategoriaResumenDto> ingresos = new ArrayList<>();
+        List<GastoReservadoCategoriaResumenDto> egresos = new ArrayList<>();
+
+        BigDecimal totalIngresosReservado = BigDecimal.ZERO;
+        BigDecimal totalIngresosAplicado = BigDecimal.ZERO;
+        BigDecimal totalEgresosReservado = BigDecimal.ZERO;
+        BigDecimal totalEgresosAplicado = BigDecimal.ZERO;
+
+        for (GastoReservadoCategoriaResumenProjection resumen : resumenes) {
+            BigDecimal montoReservado = valueOrZero(resumen.getTotalMontoReservado());
+            BigDecimal montoAplicado = valueOrZero(resumen.getTotalMontoAplicado());
+
+            GastoReservadoCategoriaResumenDto dto = new GastoReservadoCategoriaResumenDto(
+                    resumen.getCategoriaId(),
+                    resumen.getCategoriaNombre(),
+                    resumen.getTipo(),
+                    resumen.getCategoriaOrden(),
+                    montoReservado,
+                    montoAplicado
+            );
+
+            if (resumen.getTipo() == TipoFin.INGRESO) {
+                ingresos.add(dto);
+                totalIngresosReservado = totalIngresosReservado.add(montoReservado);
+                totalIngresosAplicado = totalIngresosAplicado.add(montoAplicado);
+            } else {
+                egresos.add(dto);
+                totalEgresosReservado = totalEgresosReservado.add(montoReservado);
+                totalEgresosAplicado = totalEgresosAplicado.add(montoAplicado);
+            }
+        }
+
+        Comparator<GastoReservadoCategoriaResumenDto> comparator = Comparator
+                .comparing(GastoReservadoCategoriaResumenDto::getOrden,
+                        Comparator.nullsLast(Integer::compareTo))
+                .thenComparing(GastoReservadoCategoriaResumenDto::getCategoriaNombre,
+                        String.CASE_INSENSITIVE_ORDER);
+        ingresos.sort(comparator);
+        egresos.sort(comparator);
+
+        GastoReservadoTotalesDto totalIngresos = new GastoReservadoTotalesDto(
+                totalIngresosReservado, totalIngresosAplicado);
+        GastoReservadoTotalesDto totalEgresos = new GastoReservadoTotalesDto(
+                totalEgresosReservado, totalEgresosAplicado);
+        GastoReservadoTotalesDto totalGeneral = new GastoReservadoTotalesDto(
+                totalIngresosReservado.subtract(totalEgresosReservado),
+                totalIngresosAplicado.subtract(totalEgresosAplicado));
+
+        return new PeriodoFinancieroReservasResumenDto(
+                ingresos,
+                totalIngresos,
+                egresos,
+                totalEgresos,
+                totalGeneral
+        );
+    }
+
     private void ensureCerradoFlag(PeriodoFinanciero periodoFinanciero) {
         if (periodoFinanciero.getCerrado() == null) {
             periodoFinanciero.setCerrado(Boolean.FALSE);
         }
+    }
+
+    private BigDecimal valueOrZero(BigDecimal value) {
+        return value != null ? value : BigDecimal.ZERO;
     }
 }

--- a/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
@@ -2,11 +2,16 @@ package com.ahumadamob.fnanz.controller;
 
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroCreateDto;
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroPatchDto;
+import com.ahumadamob.fnanz.dto.response.GastoReservadoCategoriaResumenDto;
+import com.ahumadamob.fnanz.dto.response.GastoReservadoTotalesDto;
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroReservasResumenDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import com.ahumadamob.fnanz.enums.TipoFin;
 import com.ahumadamob.fnanz.mapper.PeriodoFinancieroMapper;
 import com.ahumadamob.fnanz.service.PeriodoFinancieroService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -177,6 +182,46 @@ class PeriodoFinancieroControllerTest {
 
         verify(periodoFinancieroService).get(4L);
         verify(periodoFinancieroMapper).toDto(periodo);
+        verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
+    }
+
+    @Test
+    void getResumenReservasShouldReturnAggregatedData() throws Exception {
+        PeriodoFinancieroReservasResumenDto resumen = new PeriodoFinancieroReservasResumenDto(
+                List.of(new GastoReservadoCategoriaResumenDto(
+                        1L,
+                        "Salario",
+                        TipoFin.INGRESO,
+                        1,
+                        new BigDecimal("1200.00"),
+                        new BigDecimal("1100.00")
+                )),
+                new GastoReservadoTotalesDto(new BigDecimal("1200.00"), new BigDecimal("1100.00")),
+                List.of(new GastoReservadoCategoriaResumenDto(
+                        2L,
+                        "Renta",
+                        TipoFin.EGRESO,
+                        1,
+                        new BigDecimal("700.00"),
+                        new BigDecimal("650.00")
+                )),
+                new GastoReservadoTotalesDto(new BigDecimal("700.00"), new BigDecimal("650.00")),
+                new GastoReservadoTotalesDto(new BigDecimal("500.00"), new BigDecimal("450.00"))
+        );
+
+        when(periodoFinancieroService.obtenerResumenReservas(9L)).thenReturn(resumen);
+
+        mockMvc.perform(get("/api/periodos-financieros/{id}/reservas-resumen", 9L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.ingresos", hasSize(1)))
+                .andExpect(jsonPath("$.data.ingresos[0].categoriaNombre").value("Salario"))
+                .andExpect(jsonPath("$.data.totalIngresos.montoReservado").value(1200.00))
+                .andExpect(jsonPath("$.data.egresos", hasSize(1)))
+                .andExpect(jsonPath("$.data.egresos[0].montoAplicado").value(650.00))
+                .andExpect(jsonPath("$.data.totalGeneral.montoReservado").value(500.00))
+                .andExpect(jsonPath("$.data.totalGeneral.montoAplicado").value(450.00));
+
+        verify(periodoFinancieroService).obtenerResumenReservas(9L);
         verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
     }
 

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
@@ -1,8 +1,14 @@
 package com.ahumadamob.fnanz.service.jpa;
 
+import com.ahumadamob.fnanz.dto.response.GastoReservadoCategoriaResumenDto;
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroReservasResumenDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import com.ahumadamob.fnanz.error.ResourceNotFoundException;
+import com.ahumadamob.fnanz.enums.TipoFin;
+import com.ahumadamob.fnanz.repository.GastoReservadoRepository;
 import com.ahumadamob.fnanz.repository.PeriodoFinancieroRepository;
+import com.ahumadamob.fnanz.repository.projection.GastoReservadoCategoriaResumenProjection;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +33,9 @@ class PeriodoFinancieroServiceImplTest {
 
     @Mock
     private PeriodoFinancieroRepository periodoFinancieroRepository;
+
+    @Mock
+    private GastoReservadoRepository gastoReservadoRepository;
 
     @InjectMocks
     private PeriodoFinancieroServiceImpl service;
@@ -148,6 +157,50 @@ class PeriodoFinancieroServiceImplTest {
         verify(periodoFinancieroRepository, never()).deleteById(40L);
     }
 
+    @Test
+    void obtenerResumenReservasShouldAggregateByCategoria() {
+        when(periodoFinancieroRepository.existsById(5L)).thenReturn(true);
+        when(gastoReservadoRepository.sumByPeriodoId(5L)).thenReturn(List.of(
+                projection(2L, "Consultoría", TipoFin.INGRESO, 20,
+                        new BigDecimal("500.00"), new BigDecimal("450.00")),
+                projection(1L, "Salario", TipoFin.INGRESO, 10,
+                        new BigDecimal("1000.00"), null),
+                projection(3L, "Renta", TipoFin.EGRESO, 5,
+                        new BigDecimal("600.00"), new BigDecimal("580.00"))
+        ));
+
+        PeriodoFinancieroReservasResumenDto resumen = service.obtenerResumenReservas(5L);
+
+        assertThat(resumen.getIngresos()).extracting(GastoReservadoCategoriaResumenDto::getCategoriaNombre)
+                .containsExactly("Salario", "Consultoría");
+        assertThat(resumen.getEgresos()).extracting(GastoReservadoCategoriaResumenDto::getCategoriaNombre)
+                .containsExactly("Renta");
+        assertThat(resumen.getTotalIngresos().getMontoReservado())
+                .isEqualByComparingTo(new BigDecimal("1500.00"));
+        assertThat(resumen.getTotalIngresos().getMontoAplicado())
+                .isEqualByComparingTo(new BigDecimal("450.00"));
+        assertThat(resumen.getTotalEgresos().getMontoReservado())
+                .isEqualByComparingTo(new BigDecimal("600.00"));
+        assertThat(resumen.getTotalGeneral().getMontoReservado())
+                .isEqualByComparingTo(new BigDecimal("900.00"));
+        assertThat(resumen.getTotalGeneral().getMontoAplicado())
+                .isEqualByComparingTo(new BigDecimal("-130.00"));
+
+        verify(periodoFinancieroRepository).existsById(5L);
+        verify(gastoReservadoRepository).sumByPeriodoId(5L);
+    }
+
+    @Test
+    void obtenerResumenReservasShouldThrowWhenPeriodoDoesNotExist() {
+        when(periodoFinancieroRepository.existsById(77L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.obtenerResumenReservas(77L))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(periodoFinancieroRepository).existsById(77L);
+        verify(gastoReservadoRepository, never()).sumByPeriodoId(77L);
+    }
+
     private PeriodoFinanciero buildPeriodo(Long id, String nombre, LocalDate inicio, LocalDate fin) {
         PeriodoFinanciero periodo = new PeriodoFinanciero();
         periodo.setId(id);
@@ -156,5 +209,40 @@ class PeriodoFinancieroServiceImplTest {
         periodo.setFechaFin(fin);
         periodo.setCerrado(false);
         return periodo;
+    }
+
+    private GastoReservadoCategoriaResumenProjection projection(Long categoriaId, String nombre,
+            TipoFin tipo, Integer orden, BigDecimal reservado, BigDecimal aplicado) {
+        return new GastoReservadoCategoriaResumenProjection() {
+            @Override
+            public Long getCategoriaId() {
+                return categoriaId;
+            }
+
+            @Override
+            public String getCategoriaNombre() {
+                return nombre;
+            }
+
+            @Override
+            public TipoFin getTipo() {
+                return tipo;
+            }
+
+            @Override
+            public Integer getCategoriaOrden() {
+                return orden;
+            }
+
+            @Override
+            public BigDecimal getTotalMontoReservado() {
+                return reservado;
+            }
+
+            @Override
+            public BigDecimal getTotalMontoAplicado() {
+                return aplicado;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Summary
- agregar proyección, DTOs y lógica de servicio para agrupar las reservas por categoría dentro de un periodo
- exponer el endpoint GET /api/periodos-financieros/{id}/reservas-resumen con totales por ingresos, egresos y netos
- actualizar y ampliar las pruebas del controlador y servicio para cubrir el nuevo resumen

## Testing
- mvn -q test *(falla: 403 al descargar spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68de686308e8832fb37ca02590087950