### PR TITLE
Add dropdown endpoint for periodos financieros

### DIFF
--- a/src/main/java/com/ahumadamob/fnanz/controller/GastoReservadoController.java
+++ b/src/main/java/com/ahumadamob/fnanz/controller/GastoReservadoController.java
@@ -70,6 +70,14 @@ public class GastoReservadoController {
         return page(dtoPage);
     }
 
+    @GetMapping("/periodo/{periodoId}")
+    public ApiResponseSuccessDto<List<GastoReservadoResponseDto>> listByPeriodo(@PathVariable Long periodoId) {
+        List<GastoReservadoResponseDto> gastos = gastoReservadoService.listByPeriodo(periodoId).stream()
+                .map(gastoReservadoMapper::toDto)
+                .toList();
+        return ok(gastos);
+    }
+
     @GetMapping("/{id}")
     public ApiResponseSuccessDto<GastoReservadoResponseDto> get(@PathVariable Long id) {
         GastoReservado gasto = gastoReservadoService.get(id);

--- a/src/main/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroController.java
+++ b/src/main/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroController.java
@@ -3,6 +3,7 @@ package com.ahumadamob.fnanz.controller;
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroCreateDto;
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroPatchDto;
 import com.ahumadamob.fnanz.dto.response.ApiResponseSuccessDto;
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroDropdownDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroReservasResumenDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -59,6 +61,16 @@ public class PeriodoFinancieroController {
         Page<PeriodoFinanciero> pageResult = periodoFinancieroService.list(pageable);
         Page<PeriodoFinancieroResponseDto> dtoPage = pageResult.map(periodoFinancieroMapper::toDto);
         return page(dtoPage);
+    }
+
+    @GetMapping("/dropdown")
+    public ApiResponseSuccessDto<List<PeriodoFinancieroDropdownDto>> listForDropdown(
+            @RequestParam(name = "soloAbiertos", defaultValue = "false") boolean soloAbiertos) {
+        List<PeriodoFinanciero> periodos = periodoFinancieroService.listarParaDropdown(soloAbiertos);
+        List<PeriodoFinancieroDropdownDto> dtoList = periodos.stream()
+                .map(periodoFinancieroMapper::toDropdownDto)
+                .toList();
+        return ok(dtoList);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/ahumadamob/fnanz/dto/response/PeriodoFinancieroDropdownDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/PeriodoFinancieroDropdownDto.java
@@ -1,0 +1,21 @@
+package com.ahumadamob.fnanz.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO con los datos mínimos de un {@link com.ahumadamob.fnanz.entity.PeriodoFinanciero}
+ * para ser utilizado en componentes de selección.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PeriodoFinancieroDropdownDto {
+
+    private Long id;
+
+    private String nombre;
+}

--- a/src/main/java/com/ahumadamob/fnanz/mapper/PeriodoFinancieroMapper.java
+++ b/src/main/java/com/ahumadamob/fnanz/mapper/PeriodoFinancieroMapper.java
@@ -2,6 +2,7 @@ package com.ahumadamob.fnanz.mapper;
 
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroCreateDto;
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroPatchDto;
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroDropdownDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
 import java.util.Optional;
@@ -63,6 +64,16 @@ public class PeriodoFinancieroMapper {
                 periodo.getCerrado(),
                 periodo.getCreatedAt(),
                 periodo.getUpdatedAt()
+        );
+    }
+
+    public PeriodoFinancieroDropdownDto toDropdownDto(PeriodoFinanciero periodo) {
+        if (periodo == null) {
+            return null;
+        }
+        return new PeriodoFinancieroDropdownDto(
+                periodo.getId(),
+                periodo.getNombre()
         );
     }
 }

--- a/src/main/java/com/ahumadamob/fnanz/repository/GastoReservadoRepository.java
+++ b/src/main/java/com/ahumadamob/fnanz/repository/GastoReservadoRepository.java
@@ -26,4 +26,6 @@ public interface GastoReservadoRepository extends JpaRepository<GastoReservado, 
             group by gr.categoria.id, gr.categoria.nombre, gr.categoria.tipo, gr.categoria.orden
             """)
     List<GastoReservadoCategoriaResumenProjection> sumByPeriodoId(@Param("periodoId") Long periodoId);
+
+    List<GastoReservado> findAllByPeriodoIdOrderByIdAsc(Long periodoId);
 }

--- a/src/main/java/com/ahumadamob/fnanz/repository/PeriodoFinancieroRepository.java
+++ b/src/main/java/com/ahumadamob/fnanz/repository/PeriodoFinancieroRepository.java
@@ -1,10 +1,15 @@
 package com.ahumadamob.fnanz.repository;
 
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * Repositorio JPA para {@link PeriodoFinanciero}.
  */
 public interface PeriodoFinancieroRepository extends JpaRepository<PeriodoFinanciero, Long> {
+
+    List<PeriodoFinanciero> findAllByOrderByFechaInicioAsc();
+
+    List<PeriodoFinanciero> findAllByCerradoFalseOrderByFechaInicioAsc();
 }

--- a/src/main/java/com/ahumadamob/fnanz/service/GastoReservadoService.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/GastoReservadoService.java
@@ -1,6 +1,7 @@
 package com.ahumadamob.fnanz.service;
 
 import com.ahumadamob.fnanz.entity.GastoReservado;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,4 +14,5 @@ public interface GastoReservadoService {
     GastoReservado get(Long id);
     GastoReservado update(Long id, GastoReservado gastoReservado);
     void delete(Long id);
+    List<GastoReservado> listByPeriodo(Long periodoId);
 }

--- a/src/main/java/com/ahumadamob/fnanz/service/PeriodoFinancieroService.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/PeriodoFinancieroService.java
@@ -2,6 +2,7 @@ package com.ahumadamob.fnanz.service;
 
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroReservasResumenDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,6 +14,8 @@ public interface PeriodoFinancieroService {
     PeriodoFinanciero create(PeriodoFinanciero periodoFinanciero);
 
     Page<PeriodoFinanciero> list(Pageable pageable);
+
+    List<PeriodoFinanciero> listarParaDropdown(boolean soloAbiertos);
 
     PeriodoFinanciero get(Long id);
 

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImpl.java
@@ -5,6 +5,7 @@ import com.ahumadamob.fnanz.error.ResourceConflictException;
 import com.ahumadamob.fnanz.error.ResourceNotFoundException;
 import com.ahumadamob.fnanz.repository.GastoReservadoRepository;
 import com.ahumadamob.fnanz.service.GastoReservadoService;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -48,6 +49,12 @@ public class GastoReservadoServiceImpl implements GastoReservadoService {
             );
         };
         return gastoReservadoRepository.findAll(spec, pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<GastoReservado> listByPeriodo(Long periodoId) {
+        return gastoReservadoRepository.findAllByPeriodoIdOrderByIdAsc(periodoId);
     }
 
     @Override

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
@@ -49,6 +49,15 @@ public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
 
     @Override
     @Transactional(readOnly = true)
+    public List<PeriodoFinanciero> listarParaDropdown(boolean soloAbiertos) {
+        if (soloAbiertos) {
+            return periodoFinancieroRepository.findAllByCerradoFalseOrderByFechaInicioAsc();
+        }
+        return periodoFinancieroRepository.findAllByOrderByFechaInicioAsc();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public PeriodoFinanciero get(Long id) {
         return periodoFinancieroRepository.findById(id)
                 .orElseThrow(ResourceNotFoundException::new);

--- a/src/test/java/com/ahumadamob/fnanz/controller/GastoReservadoControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/GastoReservadoControllerTest.java
@@ -247,6 +247,85 @@ class GastoReservadoControllerTest {
     }
 
     @Test
+    void listByPeriodoShouldReturnFilteredResults() throws Exception {
+        CategoriaFinanciera categoria = new CategoriaFinanciera();
+        categoria.setId(8L);
+        categoria.setNombre("Marketing");
+        categoria.setTipo(TipoFin.EGRESO);
+
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        periodo.setId(7L);
+        periodo.setNombre("Julio 2024");
+        periodo.setFechaInicio(LocalDate.of(2024, 7, 1));
+        periodo.setFechaFin(LocalDate.of(2024, 7, 31));
+
+        GastoReservado primero = new GastoReservado();
+        primero.setId(30L);
+        primero.setCategoria(categoria);
+        primero.setPeriodo(periodo);
+
+        GastoReservado segundo = new GastoReservado();
+        segundo.setId(31L);
+        segundo.setCategoria(categoria);
+        segundo.setPeriodo(periodo);
+
+        GastoReservadoResponseDto primeroDto = new GastoReservadoResponseDto(
+                30L,
+                TipoFin.EGRESO,
+                8L,
+                "Marketing",
+                "Campaña",
+                7L,
+                "Julio 2024",
+                LocalDate.of(2024, 7, 1),
+                LocalDate.of(2024, 7, 31),
+                EstadoReserva.RESERVADO,
+                new BigDecimal("1200.00"),
+                BigDecimal.ZERO,
+                null,
+                null,
+                null
+        );
+
+        GastoReservadoResponseDto segundoDto = new GastoReservadoResponseDto(
+                31L,
+                TipoFin.EGRESO,
+                8L,
+                "Marketing",
+                "Eventos",
+                7L,
+                "Julio 2024",
+                LocalDate.of(2024, 7, 1),
+                LocalDate.of(2024, 7, 31),
+                EstadoReserva.APLICADO,
+                new BigDecimal("900.00"),
+                new BigDecimal("450.00"),
+                null,
+                null,
+                null
+        );
+
+        when(gastoReservadoService.listByPeriodo(7L)).thenReturn(List.of(primero, segundo));
+        when(gastoReservadoMapper.toDto(primero)).thenReturn(primeroDto);
+        when(gastoReservadoMapper.toDto(segundo)).thenReturn(segundoDto);
+
+        mockMvc.perform(get("/api/gastos-reservados/periodo/{periodoId}", 7L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].id").value(30L))
+                .andExpect(jsonPath("$.data[0].periodoId").value(7L))
+                .andExpect(jsonPath("$.data[1].id").value(31L))
+                .andExpect(jsonPath("$.data[1].concepto").value("Eventos"))
+                .andExpect(jsonPath("$.timestamp").exists());
+
+        verify(gastoReservadoService).listByPeriodo(7L);
+        verify(gastoReservadoMapper).toDto(primero);
+        verify(gastoReservadoMapper).toDto(segundo);
+        verifyNoMoreInteractions(gastoReservadoService, gastoReservadoMapper, categoriaFinancieraService, periodoFinancieroService);
+    }
+
+    @Test
     void getShouldReturnExistingGasto() throws Exception {
         CategoriaFinanciera categoria = new CategoriaFinanciera();
         categoria.setId(7L);

--- a/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
@@ -4,6 +4,7 @@ import com.ahumadamob.fnanz.dto.PeriodoFinancieroCreateDto;
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroPatchDto;
 import com.ahumadamob.fnanz.dto.response.GastoReservadoCategoriaResumenDto;
 import com.ahumadamob.fnanz.dto.response.GastoReservadoTotalesDto;
+import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroDropdownDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroReservasResumenDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroResponseDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
@@ -136,6 +137,49 @@ class PeriodoFinancieroControllerTest {
         Assertions.assertThat(captor.getValue()).isEqualTo(PageRequest.of(0, 10));
         verify(periodoFinancieroMapper).toDto(periodo1);
         verify(periodoFinancieroMapper).toDto(periodo2);
+        verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
+    }
+
+    @Test
+    void dropdownShouldReturnOrderedListWithDefaultFilter() throws Exception {
+        PeriodoFinanciero periodo1 = buildPeriodo(1L, "Abril 2024");
+        PeriodoFinanciero periodo2 = buildPeriodo(2L, "Mayo 2024");
+        when(periodoFinancieroService.listarParaDropdown(false)).thenReturn(List.of(periodo1, periodo2));
+        when(periodoFinancieroMapper.toDropdownDto(periodo1)).thenReturn(
+                new PeriodoFinancieroDropdownDto(1L, "Abril 2024"));
+        when(periodoFinancieroMapper.toDropdownDto(periodo2)).thenReturn(
+                new PeriodoFinancieroDropdownDto(2L, "Mayo 2024"));
+
+        mockMvc.perform(get("/api/periodos-financieros/dropdown"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].id").value(1L))
+                .andExpect(jsonPath("$.data[0].nombre").value("Abril 2024"))
+                .andExpect(jsonPath("$.data[1].id").value(2L))
+                .andExpect(jsonPath("$.data[1].nombre").value("Mayo 2024"));
+
+        verify(periodoFinancieroService).listarParaDropdown(false);
+        verify(periodoFinancieroMapper).toDropdownDto(periodo1);
+        verify(periodoFinancieroMapper).toDropdownDto(periodo2);
+        verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
+    }
+
+    @Test
+    void dropdownShouldAllowFilteringByAbiertos() throws Exception {
+        PeriodoFinanciero periodo = buildPeriodo(3L, "Junio 2024");
+        when(periodoFinancieroService.listarParaDropdown(true)).thenReturn(List.of(periodo));
+        when(periodoFinancieroMapper.toDropdownDto(periodo)).thenReturn(
+                new PeriodoFinancieroDropdownDto(3L, "Junio 2024"));
+
+        mockMvc.perform(get("/api/periodos-financieros/dropdown")
+                        .param("soloAbiertos", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].id").value(3L))
+                .andExpect(jsonPath("$.data[0].nombre").value("Junio 2024"));
+
+        verify(periodoFinancieroService).listarParaDropdown(true);
+        verify(periodoFinancieroMapper).toDropdownDto(periodo);
         verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);
     }
 

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/GastoReservadoServiceImplTest.java
@@ -197,6 +197,22 @@ class GastoReservadoServiceImplTest {
         assertThat(captor.getValue()).isNotNull();
     }
 
+    @Test
+    void listByPeriodoShouldDelegateToRepository() {
+        CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
+        PeriodoFinanciero periodo = buildPeriodo(3L, LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31));
+        GastoReservado primero = buildGasto(10L, TipoFin.EGRESO, categoria, periodo);
+        GastoReservado segundo = buildGasto(12L, TipoFin.EGRESO, categoria, periodo);
+        List<GastoReservado> expected = List.of(primero, segundo);
+
+        when(gastoReservadoRepository.findAllByPeriodoIdOrderByIdAsc(3L)).thenReturn(expected);
+
+        List<GastoReservado> result = service.listByPeriodo(3L);
+
+        assertThat(result).isSameAs(expected);
+        verify(gastoReservadoRepository).findAllByPeriodoIdOrderByIdAsc(3L);
+    }
+
     private CategoriaFinanciera buildCategoria(Long id, String nombre, TipoFin tipo) {
         CategoriaFinanciera categoria = new CategoriaFinanciera();
         categoria.setId(id);

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
@@ -82,6 +82,33 @@ class PeriodoFinancieroServiceImplTest {
     }
 
     @Test
+    void listarParaDropdownShouldReturnAllOrderedWhenSoloAbiertosIsFalse() {
+        List<PeriodoFinanciero> periodos = List.of(
+                buildPeriodo(1L, "Enero", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31)),
+                buildPeriodo(2L, "Febrero", LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 29))
+        );
+        when(periodoFinancieroRepository.findAllByOrderByFechaInicioAsc()).thenReturn(periodos);
+
+        List<PeriodoFinanciero> result = service.listarParaDropdown(false);
+
+        assertThat(result).isEqualTo(periodos);
+        verify(periodoFinancieroRepository).findAllByOrderByFechaInicioAsc();
+    }
+
+    @Test
+    void listarParaDropdownShouldFilterClosedWhenSoloAbiertosIsTrue() {
+        List<PeriodoFinanciero> abiertos = List.of(
+                buildPeriodo(3L, "Marzo", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 31))
+        );
+        when(periodoFinancieroRepository.findAllByCerradoFalseOrderByFechaInicioAsc()).thenReturn(abiertos);
+
+        List<PeriodoFinanciero> result = service.listarParaDropdown(true);
+
+        assertThat(result).isEqualTo(abiertos);
+        verify(periodoFinancieroRepository).findAllByCerradoFalseOrderByFechaInicioAsc();
+    }
+
+    @Test
     void getShouldThrowWhenPeriodoDoesNotExist() {
         when(periodoFinancieroRepository.findById(9L)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
## Summary
- add a dropdown endpoint to list periodos financieros ordered by start date
- introduce a lightweight dropdown DTO and repository helpers to fetch open or all periods
- cover the new controller endpoint and service branch logic with focused unit tests

## Testing
- mvn -q test *(fails: cannot resolve Spring Boot parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e18f5900a0832f8dab3e3469b87a1b