### PR TITLE
Add PATCH endpoint to apply budget allocation

### DIFF
--- a/src/main/java/com/ahumadamob/fnanz/controller/PartidaPresupuestariaController.java
+++ b/src/main/java/com/ahumadamob/fnanz/controller/PartidaPresupuestariaController.java
@@ -1,5 +1,6 @@
 package com.ahumadamob.fnanz.controller;
 
+import com.ahumadamob.fnanz.dto.PartidaPresupuestariaAplicarDto;
 import com.ahumadamob.fnanz.dto.PartidaPresupuestariaCreateDto;
 import com.ahumadamob.fnanz.dto.PartidaPresupuestariaPatchDto;
 import com.ahumadamob.fnanz.dto.response.ApiResponseSuccessDto;
@@ -97,6 +98,13 @@ public class PartidaPresupuestariaController {
         PartidaPresupuestaria cambios = partidaPresupuestariaMapper.toPartialEntity(dto, categoria, periodo);
         PartidaPresupuestaria updated = partidaPresupuestariaService.update(id, cambios);
         return ok(partidaPresupuestariaMapper.toDto(updated));
+    }
+
+    @PatchMapping("/{id}/aplicar")
+    public ApiResponseSuccessDto<PartidaPresupuestariaResponseDto> apply(@PathVariable Long id,
+            @Validated @RequestBody PartidaPresupuestariaAplicarDto dto) {
+        PartidaPresupuestaria aplicada = partidaPresupuestariaService.applyMonto(id, dto.getMontoAplicado());
+        return ok(partidaPresupuestariaMapper.toDto(aplicada));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/ahumadamob/fnanz/dto/PartidaPresupuestariaAplicarDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/PartidaPresupuestariaAplicarDto.java
@@ -1,0 +1,23 @@
+package com.ahumadamob.fnanz.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO para aplicar una partida presupuestaria.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class PartidaPresupuestariaAplicarDto {
+
+    @NotNull
+    @DecimalMin(value = "0.00")
+    @Digits(integer = 14, fraction = 2)
+    private BigDecimal montoAplicado;
+}

--- a/src/main/java/com/ahumadamob/fnanz/service/PartidaPresupuestariaService.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/PartidaPresupuestariaService.java
@@ -1,6 +1,7 @@
 package com.ahumadamob.fnanz.service;
 
 import com.ahumadamob.fnanz.entity.PartidaPresupuestaria;
+import java.math.BigDecimal;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,7 @@ public interface PartidaPresupuestariaService {
     Page<PartidaPresupuestaria> list(String q, Pageable pageable);
     PartidaPresupuestaria get(Long id);
     PartidaPresupuestaria update(Long id, PartidaPresupuestaria partidaPresupuestaria);
+    PartidaPresupuestaria applyMonto(Long id, BigDecimal montoAplicado);
     void delete(Long id);
     List<PartidaPresupuestaria> listByPeriodo(Long periodoId);
 }

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/PartidaPresupuestariaServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/PartidaPresupuestariaServiceImpl.java
@@ -1,10 +1,12 @@
 package com.ahumadamob.fnanz.service.jpa;
 
 import com.ahumadamob.fnanz.entity.PartidaPresupuestaria;
+import com.ahumadamob.fnanz.enums.EstadoReserva;
 import com.ahumadamob.fnanz.error.ResourceConflictException;
 import com.ahumadamob.fnanz.error.ResourceNotFoundException;
 import com.ahumadamob.fnanz.repository.PartidaPresupuestariaRepository;
 import com.ahumadamob.fnanz.service.PartidaPresupuestariaService;
+import java.math.BigDecimal;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -95,6 +97,27 @@ public class PartidaPresupuestariaServiceImpl implements PartidaPresupuestariaSe
         }
 
         validateCategoriaTipoYPeriodo(partida);
+        return partidaPresupuestariaRepository.save(partida);
+    }
+
+    @Override
+    public PartidaPresupuestaria applyMonto(Long id, BigDecimal montoAplicado) {
+        PartidaPresupuestaria partida = partidaPresupuestariaRepository.findById(id)
+                .orElseThrow(ResourceNotFoundException::new);
+
+        if (montoAplicado == null) {
+            throw new ResourceConflictException("montoAplicado", "El monto aplicado es obligatorio");
+        }
+        if (montoAplicado.compareTo(BigDecimal.ZERO) < 0) {
+            throw new ResourceConflictException("montoAplicado", "El monto aplicado debe ser mayor o igual a cero");
+        }
+        BigDecimal montoReservado = partida.getMontoReservado();
+        if (montoReservado != null && montoAplicado.compareTo(montoReservado) > 0) {
+            throw new ResourceConflictException("montoAplicado", "El monto aplicado no puede superar el monto reservado");
+        }
+
+        partida.setMontoAplicado(montoAplicado);
+        partida.setEstado(EstadoReserva.APLICADO);
         return partidaPresupuestariaRepository.save(partida);
     }
 

--- a/src/test/java/com/ahumadamob/fnanz/controller/PartidaPresupuestariaControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/PartidaPresupuestariaControllerTest.java
@@ -1,5 +1,6 @@
 package com.ahumadamob.fnanz.controller;
 
+import com.ahumadamob.fnanz.dto.PartidaPresupuestariaAplicarDto;
 import com.ahumadamob.fnanz.dto.PartidaPresupuestariaCreateDto;
 import com.ahumadamob.fnanz.dto.PartidaPresupuestariaPatchDto;
 import com.ahumadamob.fnanz.dto.response.PartidaPresupuestariaResponseDto;
@@ -451,6 +452,65 @@ class PartidaPresupuestariaControllerTest {
     }
 
     @Test
+    void applyShouldSetMontoAplicadoAndReturnUpdatedPartida() throws Exception {
+        PartidaPresupuestariaAplicarDto requestDto = new PartidaPresupuestariaAplicarDto();
+        requestDto.setMontoAplicado(new BigDecimal("1200.00"));
+
+        CategoriaFinanciera categoria = new CategoriaFinanciera();
+        categoria.setId(5L);
+        categoria.setNombre("Servicios");
+        categoria.setTipo(TipoFin.EGRESO);
+
+        PeriodoFinanciero periodo = new PeriodoFinanciero();
+        periodo.setId(7L);
+        periodo.setNombre("Mayo 2024");
+        periodo.setFechaInicio(LocalDate.of(2024, 5, 1));
+        periodo.setFechaFin(LocalDate.of(2024, 5, 31));
+
+        PartidaPresupuestaria partidaAplicada = new PartidaPresupuestaria();
+        partidaAplicada.setId(15L);
+        partidaAplicada.setTipo(TipoFin.EGRESO);
+        partidaAplicada.setCategoria(categoria);
+        partidaAplicada.setPeriodo(periodo);
+        partidaAplicada.setEstado(EstadoReserva.APLICADO);
+        partidaAplicada.setMontoReservado(new BigDecimal("1500.00"));
+        partidaAplicada.setMontoAplicado(new BigDecimal("1200.00"));
+
+        PartidaPresupuestariaResponseDto responseDto = new PartidaPresupuestariaResponseDto(
+                15L,
+                TipoFin.EGRESO,
+                5L,
+                "Servicios",
+                "Pago consultoría",
+                7L,
+                "Mayo 2024",
+                LocalDate.of(2024, 5, 1),
+                LocalDate.of(2024, 5, 31),
+                EstadoReserva.APLICADO,
+                new BigDecimal("1500.00"),
+                new BigDecimal("1200.00"),
+                "Mensual",
+                LocalDateTime.of(2024, 5, 3, 10, 0),
+                LocalDateTime.of(2024, 5, 4, 10, 0)
+        );
+
+        when(partidaPresupuestariaService.applyMonto(15L, new BigDecimal("1200.00"))).thenReturn(partidaAplicada);
+        when(partidaPresupuestariaMapper.toDto(partidaAplicada)).thenReturn(responseDto);
+
+        mockMvc.perform(patch("/api/partidas-presupuestarias/{id}/aplicar", 15L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(15L))
+                .andExpect(jsonPath("$.data.estado").value(EstadoReserva.APLICADO.name()))
+                .andExpect(jsonPath("$.data.montoAplicado").value(1200.00));
+
+        verify(partidaPresupuestariaService).applyMonto(15L, new BigDecimal("1200.00"));
+        verify(partidaPresupuestariaMapper).toDto(partidaAplicada);
+        verifyNoMoreInteractions(partidaPresupuestariaService, partidaPresupuestariaMapper);
+    }
+
+    @Test
     void deleteShouldReturnNoContent() throws Exception {
         doNothing().when(partidaPresupuestariaService).delete(55L);
 
@@ -460,5 +520,5 @@ class PartidaPresupuestariaControllerTest {
         verify(partidaPresupuestariaService).delete(55L);
         verifyNoMoreInteractions(partidaPresupuestariaService);
         verifyNoMoreInteractions(categoriaFinancieraService, partidaPresupuestariaMapper, periodoFinancieroService);
-}
+    }
 }

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/PartidaPresupuestariaServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/PartidaPresupuestariaServiceImplTest.java
@@ -153,6 +153,46 @@ class PartidaPresupuestariaServiceImplTest {
     }
 
     @Test
+    void applyMontoShouldUpdateMontoAplicadoAndEstado() {
+        CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
+        PeriodoFinanciero periodo = buildPeriodo(1L, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31));
+        PartidaPresupuestaria partida = buildPartida(10L, TipoFin.EGRESO, categoria, periodo);
+        partida.setEstado(EstadoReserva.RESERVADO);
+        partida.setMontoReservado(new BigDecimal("1500.00"));
+
+        when(partidaPresupuestariaRepository.findById(10L)).thenReturn(Optional.of(partida));
+        when(partidaPresupuestariaRepository.save(partida)).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PartidaPresupuestaria result = service.applyMonto(10L, new BigDecimal("1200.00"));
+
+        assertThat(result.getMontoAplicado()).isEqualByComparingTo("1200.00");
+        assertThat(result.getEstado()).isEqualTo(EstadoReserva.APLICADO);
+        verify(partidaPresupuestariaRepository).save(partida);
+    }
+
+    @Test
+    void applyMontoShouldThrowConflictWhenMontoExceedsReservado() {
+        CategoriaFinanciera categoria = buildCategoria(1L, "Servicios", TipoFin.EGRESO);
+        PeriodoFinanciero periodo = buildPeriodo(1L, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31));
+        PartidaPresupuestaria partida = buildPartida(10L, TipoFin.EGRESO, categoria, periodo);
+        partida.setMontoReservado(new BigDecimal("1000.00"));
+
+        when(partidaPresupuestariaRepository.findById(10L)).thenReturn(Optional.of(partida));
+
+        assertThatThrownBy(() -> service.applyMonto(10L, new BigDecimal("1200.00")))
+                .isInstanceOf(ResourceConflictException.class);
+        verify(partidaPresupuestariaRepository, never()).save(any());
+    }
+
+    @Test
+    void applyMontoShouldThrowWhenPartidaDoesNotExist() {
+        when(partidaPresupuestariaRepository.findById(10L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.applyMonto(10L, new BigDecimal("100.00")))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
     void deleteShouldRemovePartidaWhenExists() {
         when(partidaPresupuestariaRepository.existsById(3L)).thenReturn(true);
 


### PR DESCRIPTION
## Summary
- add a PATCH endpoint that applies a budget allocation by amount and switches the reservation status to applied
- introduce a dedicated request DTO and service logic to validate and persist the applied amount
- extend controller and service tests to cover the new application workflow

## Testing
- mvn test *(fails: unable to download org.springframework.boot:spring-boot-starter-parent:3.2.5 because Maven Central returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b1fcc3f4832fa114caf2b4bfc3a8