### PR TITLE
Add net totals to financial period summary response

### DIFF
--- a/src/main/java/com/ahumadamob/fnanz/dto/response/PartidaPresupuestariaResumenDetalleDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/PartidaPresupuestariaResumenDetalleDto.java
@@ -1,0 +1,21 @@
+package com.ahumadamob.fnanz.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO que agrupa las categorías con sus totales para ingresos o egresos.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PartidaPresupuestariaResumenDetalleDto {
+
+    private List<PartidaPresupuestariaCategoriaResumenDto> categorias;
+
+    private PartidaPresupuestariaTotalesDto totales;
+}

--- a/src/main/java/com/ahumadamob/fnanz/dto/response/PeriodoFinancieroPartidasResumenDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/PeriodoFinancieroPartidasResumenDto.java
@@ -1,7 +1,6 @@
 package com.ahumadamob.fnanz.dto.response;
 
 import java.math.BigDecimal;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,18 +15,11 @@ import lombok.Setter;
 @AllArgsConstructor
 public class PeriodoFinancieroPartidasResumenDto {
 
-    private List<PartidaPresupuestariaCategoriaResumenDto> ingresos;
+    private PartidaPresupuestariaResumenDetalleDto ingresos;
 
-    private PartidaPresupuestariaTotalesDto totalIngresos;
-
-    private List<PartidaPresupuestariaCategoriaResumenDto> egresos;
-
-    private PartidaPresupuestariaTotalesDto totalEgresos;
-
-    private PartidaPresupuestariaTotalesDto totalGeneral;
+    private PartidaPresupuestariaResumenDetalleDto egresos;
 
     private BigDecimal netoReservado;
 
     private BigDecimal netoAplicado;
 }
-

--- a/src/main/java/com/ahumadamob/fnanz/dto/response/PeriodoFinancieroPartidasResumenDto.java
+++ b/src/main/java/com/ahumadamob/fnanz/dto/response/PeriodoFinancieroPartidasResumenDto.java
@@ -1,5 +1,6 @@
 package com.ahumadamob.fnanz.dto.response;
 
+import java.math.BigDecimal;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,5 +25,9 @@ public class PeriodoFinancieroPartidasResumenDto {
     private PartidaPresupuestariaTotalesDto totalEgresos;
 
     private PartidaPresupuestariaTotalesDto totalGeneral;
+
+    private BigDecimal netoReservado;
+
+    private BigDecimal netoAplicado;
 }
 

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ahumadamob.fnanz.service.jpa;
 
 import com.ahumadamob.fnanz.dto.response.PartidaPresupuestariaCategoriaResumenDto;
+import com.ahumadamob.fnanz.dto.response.PartidaPresupuestariaResumenDetalleDto;
 import com.ahumadamob.fnanz.dto.response.PartidaPresupuestariaTotalesDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroPartidasResumenDto;
 import com.ahumadamob.fnanz.entity.PeriodoFinanciero;
@@ -125,8 +126,8 @@ public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
         List<PartidaPresupuestariaCategoriaResumenProjection> resumenes =
                 partidaPresupuestariaRepository.sumByPeriodoId(id);
 
-        List<PartidaPresupuestariaCategoriaResumenDto> ingresos = new ArrayList<>();
-        List<PartidaPresupuestariaCategoriaResumenDto> egresos = new ArrayList<>();
+        List<PartidaPresupuestariaCategoriaResumenDto> ingresosCategorias = new ArrayList<>();
+        List<PartidaPresupuestariaCategoriaResumenDto> egresosCategorias = new ArrayList<>();
 
         BigDecimal totalIngresosReservado = BigDecimal.ZERO;
         BigDecimal totalIngresosAplicado = BigDecimal.ZERO;
@@ -147,11 +148,11 @@ public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
             );
 
             if (resumen.getTipo() == TipoFin.INGRESO) {
-                ingresos.add(dto);
+                ingresosCategorias.add(dto);
                 totalIngresosReservado = totalIngresosReservado.add(montoReservado);
                 totalIngresosAplicado = totalIngresosAplicado.add(montoAplicado);
             } else {
-                egresos.add(dto);
+                egresosCategorias.add(dto);
                 totalEgresosReservado = totalEgresosReservado.add(montoReservado);
                 totalEgresosAplicado = totalEgresosAplicado.add(montoAplicado);
             }
@@ -162,25 +163,23 @@ public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
                         Comparator.nullsLast(Integer::compareTo))
                 .thenComparing(PartidaPresupuestariaCategoriaResumenDto::getCategoriaNombre,
                         String.CASE_INSENSITIVE_ORDER);
-        ingresos.sort(comparator);
-        egresos.sort(comparator);
+        ingresosCategorias.sort(comparator);
+        egresosCategorias.sort(comparator);
 
         PartidaPresupuestariaTotalesDto totalIngresos = new PartidaPresupuestariaTotalesDto(
                 totalIngresosReservado, totalIngresosAplicado);
         PartidaPresupuestariaTotalesDto totalEgresos = new PartidaPresupuestariaTotalesDto(
                 totalEgresosReservado, totalEgresosAplicado);
+        PartidaPresupuestariaResumenDetalleDto ingresos = new PartidaPresupuestariaResumenDetalleDto(
+                ingresosCategorias, totalIngresos);
+        PartidaPresupuestariaResumenDetalleDto egresos = new PartidaPresupuestariaResumenDetalleDto(
+                egresosCategorias, totalEgresos);
         BigDecimal netoReservado = totalIngresosReservado.subtract(totalEgresosReservado);
         BigDecimal netoAplicado = totalIngresosAplicado.subtract(totalEgresosAplicado);
-        PartidaPresupuestariaTotalesDto totalGeneral = new PartidaPresupuestariaTotalesDto(
-                netoReservado,
-                netoAplicado);
 
         return new PeriodoFinancieroPartidasResumenDto(
                 ingresos,
-                totalIngresos,
                 egresos,
-                totalEgresos,
-                totalGeneral,
                 netoReservado,
                 netoAplicado
         );

--- a/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
+++ b/src/main/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImpl.java
@@ -169,16 +169,20 @@ public class PeriodoFinancieroServiceImpl implements PeriodoFinancieroService {
                 totalIngresosReservado, totalIngresosAplicado);
         PartidaPresupuestariaTotalesDto totalEgresos = new PartidaPresupuestariaTotalesDto(
                 totalEgresosReservado, totalEgresosAplicado);
+        BigDecimal netoReservado = totalIngresosReservado.subtract(totalEgresosReservado);
+        BigDecimal netoAplicado = totalIngresosAplicado.subtract(totalEgresosAplicado);
         PartidaPresupuestariaTotalesDto totalGeneral = new PartidaPresupuestariaTotalesDto(
-                totalIngresosReservado.subtract(totalEgresosReservado),
-                totalIngresosAplicado.subtract(totalEgresosAplicado));
+                netoReservado,
+                netoAplicado);
 
         return new PeriodoFinancieroPartidasResumenDto(
                 ingresos,
                 totalIngresos,
                 egresos,
                 totalEgresos,
-                totalGeneral
+                totalGeneral,
+                netoReservado,
+                netoAplicado
         );
     }
 

--- a/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
@@ -3,6 +3,7 @@ package com.ahumadamob.fnanz.controller;
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroCreateDto;
 import com.ahumadamob.fnanz.dto.PeriodoFinancieroPatchDto;
 import com.ahumadamob.fnanz.dto.response.PartidaPresupuestariaCategoriaResumenDto;
+import com.ahumadamob.fnanz.dto.response.PartidaPresupuestariaResumenDetalleDto;
 import com.ahumadamob.fnanz.dto.response.PartidaPresupuestariaTotalesDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroDropdownDto;
 import com.ahumadamob.fnanz.dto.response.PeriodoFinancieroPartidasResumenDto;
@@ -231,7 +232,7 @@ class PeriodoFinancieroControllerTest {
 
     @Test
     void getResumenPartidasShouldReturnAggregatedData() throws Exception {
-        PeriodoFinancieroPartidasResumenDto resumen = new PeriodoFinancieroPartidasResumenDto(
+        PartidaPresupuestariaResumenDetalleDto ingresos = new PartidaPresupuestariaResumenDetalleDto(
                 List.of(new PartidaPresupuestariaCategoriaResumenDto(
                         1L,
                         "Salario",
@@ -240,7 +241,9 @@ class PeriodoFinancieroControllerTest {
                         new BigDecimal("1200.00"),
                         new BigDecimal("1100.00")
                 )),
-                new PartidaPresupuestariaTotalesDto(new BigDecimal("1200.00"), new BigDecimal("1100.00")),
+                new PartidaPresupuestariaTotalesDto(new BigDecimal("1200.00"), new BigDecimal("1100.00"))
+        );
+        PartidaPresupuestariaResumenDetalleDto egresos = new PartidaPresupuestariaResumenDetalleDto(
                 List.of(new PartidaPresupuestariaCategoriaResumenDto(
                         2L,
                         "Renta",
@@ -249,8 +252,11 @@ class PeriodoFinancieroControllerTest {
                         new BigDecimal("700.00"),
                         new BigDecimal("650.00")
                 )),
-                new PartidaPresupuestariaTotalesDto(new BigDecimal("700.00"), new BigDecimal("650.00")),
-                new PartidaPresupuestariaTotalesDto(new BigDecimal("500.00"), new BigDecimal("450.00")),
+                new PartidaPresupuestariaTotalesDto(new BigDecimal("700.00"), new BigDecimal("650.00"))
+        );
+        PeriodoFinancieroPartidasResumenDto resumen = new PeriodoFinancieroPartidasResumenDto(
+                ingresos,
+                egresos,
                 new BigDecimal("500.00"),
                 new BigDecimal("450.00")
         );
@@ -259,13 +265,13 @@ class PeriodoFinancieroControllerTest {
 
         mockMvc.perform(get("/api/periodos-financieros/{id}/partidas-resumen", 9L))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.ingresos", hasSize(1)))
-                .andExpect(jsonPath("$.data.ingresos[0].categoriaNombre").value("Salario"))
-                .andExpect(jsonPath("$.data.totalIngresos.montoReservado").value(1200.00))
-                .andExpect(jsonPath("$.data.egresos", hasSize(1)))
-                .andExpect(jsonPath("$.data.egresos[0].montoAplicado").value(650.00))
-                .andExpect(jsonPath("$.data.totalGeneral.montoReservado").value(500.00))
-                .andExpect(jsonPath("$.data.totalGeneral.montoAplicado").value(450.00))
+                .andExpect(jsonPath("$.data.ingresos.categorias", hasSize(1)))
+                .andExpect(jsonPath("$.data.ingresos.categorias[0].categoriaNombre").value("Salario"))
+                .andExpect(jsonPath("$.data.ingresos.totales.montoReservado").value(1200.00))
+                .andExpect(jsonPath("$.data.egresos.categorias", hasSize(1)))
+                .andExpect(jsonPath("$.data.egresos.categorias[0].montoAplicado").value(650.00))
+                .andExpect(jsonPath("$.data.egresos.totales.montoReservado").value(700.00))
+                .andExpect(jsonPath("$.data.egresos.totales.montoAplicado").value(650.00))
                 .andExpect(jsonPath("$.data.netoReservado").value(500.00))
                 .andExpect(jsonPath("$.data.netoAplicado").value(450.00));
 

--- a/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/controller/PeriodoFinancieroControllerTest.java
@@ -250,7 +250,9 @@ class PeriodoFinancieroControllerTest {
                         new BigDecimal("650.00")
                 )),
                 new PartidaPresupuestariaTotalesDto(new BigDecimal("700.00"), new BigDecimal("650.00")),
-                new PartidaPresupuestariaTotalesDto(new BigDecimal("500.00"), new BigDecimal("450.00"))
+                new PartidaPresupuestariaTotalesDto(new BigDecimal("500.00"), new BigDecimal("450.00")),
+                new BigDecimal("500.00"),
+                new BigDecimal("450.00")
         );
 
         when(periodoFinancieroService.obtenerResumenPartidas(9L)).thenReturn(resumen);
@@ -263,7 +265,9 @@ class PeriodoFinancieroControllerTest {
                 .andExpect(jsonPath("$.data.egresos", hasSize(1)))
                 .andExpect(jsonPath("$.data.egresos[0].montoAplicado").value(650.00))
                 .andExpect(jsonPath("$.data.totalGeneral.montoReservado").value(500.00))
-                .andExpect(jsonPath("$.data.totalGeneral.montoAplicado").value(450.00));
+                .andExpect(jsonPath("$.data.totalGeneral.montoAplicado").value(450.00))
+                .andExpect(jsonPath("$.data.netoReservado").value(500.00))
+                .andExpect(jsonPath("$.data.netoAplicado").value(450.00));
 
         verify(periodoFinancieroService).obtenerResumenPartidas(9L);
         verifyNoMoreInteractions(periodoFinancieroService, periodoFinancieroMapper);

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
@@ -198,20 +198,20 @@ class PeriodoFinancieroServiceImplTest {
 
         PeriodoFinancieroPartidasResumenDto resumen = service.obtenerResumenPartidas(5L);
 
-        assertThat(resumen.getIngresos()).extracting(PartidaPresupuestariaCategoriaResumenDto::getCategoriaNombre)
+        assertThat(resumen.getIngresos().getCategorias())
+                .extracting(PartidaPresupuestariaCategoriaResumenDto::getCategoriaNombre)
                 .containsExactly("Salario", "Consultoría");
-        assertThat(resumen.getEgresos()).extracting(PartidaPresupuestariaCategoriaResumenDto::getCategoriaNombre)
-                .containsExactly("Renta");
-        assertThat(resumen.getTotalIngresos().getMontoReservado())
+        assertThat(resumen.getIngresos().getTotales().getMontoReservado())
                 .isEqualByComparingTo(new BigDecimal("1500.00"));
-        assertThat(resumen.getTotalIngresos().getMontoAplicado())
+        assertThat(resumen.getIngresos().getTotales().getMontoAplicado())
                 .isEqualByComparingTo(new BigDecimal("450.00"));
-        assertThat(resumen.getTotalEgresos().getMontoReservado())
+        assertThat(resumen.getEgresos().getCategorias())
+                .extracting(PartidaPresupuestariaCategoriaResumenDto::getCategoriaNombre)
+                .containsExactly("Renta");
+        assertThat(resumen.getEgresos().getTotales().getMontoReservado())
                 .isEqualByComparingTo(new BigDecimal("600.00"));
-        assertThat(resumen.getTotalGeneral().getMontoReservado())
-                .isEqualByComparingTo(new BigDecimal("900.00"));
-        assertThat(resumen.getTotalGeneral().getMontoAplicado())
-                .isEqualByComparingTo(new BigDecimal("-130.00"));
+        assertThat(resumen.getEgresos().getTotales().getMontoAplicado())
+                .isEqualByComparingTo(new BigDecimal("580.00"));
         assertThat(resumen.getNetoReservado())
                 .isEqualByComparingTo(new BigDecimal("900.00"));
         assertThat(resumen.getNetoAplicado())

--- a/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
+++ b/src/test/java/com/ahumadamob/fnanz/service/jpa/PeriodoFinancieroServiceImplTest.java
@@ -212,6 +212,10 @@ class PeriodoFinancieroServiceImplTest {
                 .isEqualByComparingTo(new BigDecimal("900.00"));
         assertThat(resumen.getTotalGeneral().getMontoAplicado())
                 .isEqualByComparingTo(new BigDecimal("-130.00"));
+        assertThat(resumen.getNetoReservado())
+                .isEqualByComparingTo(new BigDecimal("900.00"));
+        assertThat(resumen.getNetoAplicado())
+                .isEqualByComparingTo(new BigDecimal("-130.00"));
 
         verify(periodoFinancieroRepository).existsById(5L);
         verify(partidaPresupuestariaRepository).sumByPeriodoId(5L);


### PR DESCRIPTION
## Summary
- add netoReservado and netoAplicado fields to the financial period summary DTO
- calculate the new net totals from ingresos and egresos in the service layer
- update controller and service tests to cover the new response fields

## Testing
- `mvn test` *(fails: unable to download parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68ec1889fe4c832faf5a44e4484cff53